### PR TITLE
fix(security): encode redirect_uri, limit state payload, fix iframe timeout

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -116,8 +116,8 @@ export class Authorizer {
       if (err.error) {
         window.location.replace(
           `${this.config.authorizerURL}/app?state=${encode(
-            JSON.stringify(this.config),
-          )}&redirect_uri=${this.config.redirectURL}`,
+            JSON.stringify({ clientID: this.config.clientID, redirectURL: this.config.redirectURL, authorizerURL: this.config.authorizerURL }),
+          )}&redirect_uri=${encodeURIComponent(this.config.redirectURL || '')}`,
         );
       }
 
@@ -142,8 +142,8 @@ export class Authorizer {
 
       window.location.replace(
         `${this.config.authorizerURL}/app?state=${encode(
-          JSON.stringify(this.config),
-        )}&redirect_uri=${this.config.redirectURL}`,
+          JSON.stringify({ clientID: this.config.clientID, redirectURL: this.config.redirectURL, authorizerURL: this.config.authorizerURL }),
+        )}&redirect_uri=${encodeURIComponent(this.config.redirectURL || '')}`,
       );
       return this.errorResponse(err);
     }
@@ -350,9 +350,9 @@ export class Authorizer {
     if (roles && roles.length) urlState += `&roles=${roles.join(',')}`;
 
     window.location.replace(
-      `${this.config.authorizerURL}/oauth_login/${oauthProvider}?redirect_uri=${
-        redirect_uri || this.config.redirectURL
-      }&state=${urlState}`,
+      `${this.config.authorizerURL}/oauth_login/${oauthProvider}?redirect_uri=${encodeURIComponent(
+        redirect_uri || this.config.redirectURL || ''
+      )}&state=${encodeURIComponent(urlState)}`,
     );
   };
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -124,6 +124,7 @@ export const executeIframe = (
     };
 
     const timeoutSetTimeoutId = setTimeout(() => {
+      reject(new Error('Authorization timeout'));
       removeIframe();
     }, timeoutInSeconds * 1000);
 


### PR DESCRIPTION
## Summary
- **URL encoding (HIGH)**: `redirect_uri` and `state` params in OAuth login URLs are now properly URL-encoded with `encodeURIComponent()`
- **State payload (HIGH)**: URL state parameter now only serializes `clientID`, `redirectURL`, `authorizerURL` — no longer leaks `extraHeaders` or other config
- **iframe timeout (MEDIUM)**: `executeIframe` timeout now properly rejects the promise instead of silently hanging

## Files Changed
- `src/index.ts` — URL encoding + state payload limiting
- `src/utils.ts` — iframe timeout rejection

## Test plan
- [ ] Verify OAuth login flow works with special characters in redirect_uri
- [ ] Verify state parameter no longer contains extraHeaders
- [ ] Verify iframe timeout surfaces error to caller