### PR TITLE
feat: add fine-grained authorization (FGA) support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: "18" # Specify your Node.js version here
+          node-version: "20" # testcontainers (FGA integration tests) needs Node >= 20 (global File)
 
       - name: Set up pnpm
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ package-lock.json
 .env
 .env.*
 .pnpm-store
+# Local planning artifacts (not for publication)
+docs/superpowers/

--- a/README.md
+++ b/README.md
@@ -131,6 +131,36 @@ async function main() {
 }
 ```
 
+## Fine-grained authorization (FGA)
+
+Authorizer supports resource:scope based fine-grained permissions. The SDK exposes them in two ways.
+
+**1. Assert required permissions while validating** — pass `required_permissions` to `getSession`, `validateJWTToken` or `validateSession`. They are evaluated with AND semantics: every entry must be granted, otherwise the result is unauthorized.
+
+```js
+const { data } = await authRef.validateJWTToken({
+  token_type: 'access_token',
+  token,
+  required_permissions: [
+    { resource: 'documents', scope: 'read' },
+    { resource: 'documents', scope: 'write' },
+  ],
+});
+
+if (!data?.is_valid) {
+  // unauthorized
+}
+```
+
+**2. Fetch the principal's granted permissions** — `getPermissions` returns the resource:scope permissions for the authenticated principal. It uses the session cookie by default; in node.js pass the authorization header.
+
+```js
+const { data: permissions } = await authRef.getPermissions({
+  Authorization: `Bearer ${token}`,
+});
+// permissions => [{ resource: 'documents', scope: 'read' }, ...]
+```
+
 ## Local Development Setup
 
 ### Prerequisites

--- a/README.md
+++ b/README.md
@@ -133,32 +133,53 @@ async function main() {
 
 ## Fine-grained authorization (FGA)
 
-Authorizer supports resource:scope based fine-grained permissions. The SDK exposes them in two ways.
+Authorizer ships an embedded [OpenFGA](https://openfga.dev) engine for relationship-based
+access control (ReBAC). You model your domain as object **types** with **relations**
+(`viewer`, `editor`, `owner`…), grant access by writing **relationship tuples**
+(`user:alice` is `viewer` of `document:1`), and ask the engine whether access is allowed.
 
-**1. Assert required permissions while validating** — pass `required_permissions` to `getSession`, `validateJWTToken` or `validateSession`. They are evaluated with AND semantics: every entry must be granted, otherwise the result is unauthorized.
+Authoring the model and tuples is an admin task — do it once in the dashboard under
+**Authorization**, or via the `_fga_*` admin GraphQL API. The SDK exposes only the
+read-side checks an application needs at request time. For every call the subject
+defaults to the authenticated caller and is pinned server-side from the request
+(session cookie by default; pass the authorization header in node.js).
+
+**1. Check a single permission** — `fgaCheck` answers "does the caller have `relation`
+on `object`?".
 
 ```js
-const { data } = await authRef.validateJWTToken({
-  token_type: 'access_token',
-  token,
-  required_permissions: [
-    { resource: 'documents', scope: 'read' },
-    { resource: 'documents', scope: 'write' },
-  ],
-});
+const { data } = await authRef.fgaCheck(
+  { relation: 'can_view', object: 'document:1' },
+  { Authorization: `Bearer ${token}` }, // omit in the browser to use the cookie
+);
 
-if (!data?.is_valid) {
-  // unauthorized
+if (data?.allowed) {
+  // caller may view document:1
 }
 ```
 
-**2. Fetch the principal's granted permissions** — `getPermissions` returns the resource:scope permissions for the authenticated principal. It uses the session cookie by default; in node.js pass the authorization header.
+**2. Check many at once** — `fgaBatchCheck` evaluates several pairs in one round trip;
+`results` come back in the same order as the supplied `checks`.
 
 ```js
-const { data: permissions } = await authRef.getPermissions({
-  Authorization: `Bearer ${token}`,
+const { data } = await authRef.fgaBatchCheck({
+  checks: [
+    { relation: 'can_view', object: 'document:1' },
+    { relation: 'can_edit', object: 'document:1' },
+  ],
 });
-// permissions => [{ resource: 'documents', scope: 'read' }, ...]
+// data?.results => [{ allowed: true }, { allowed: false }]
+```
+
+**3. List accessible objects** — `fgaListObjects` returns the ids of every object of a
+type the caller relates to (handy for filtering a list to what the user can see).
+
+```js
+const { data } = await authRef.fgaListObjects({
+  relation: 'can_view',
+  object_type: 'document',
+});
+// data?.objects => ['document:1', 'document:7', ...]
 ```
 
 ## Local Development Setup

--- a/README.md
+++ b/README.md
@@ -142,40 +142,49 @@ Authoring the model and tuples is an admin task — do it once in the dashboard 
 **Authorization**, or via the `_fga_*` admin GraphQL API. The SDK exposes only the
 read-side checks an application needs at request time. For every call the subject
 defaults to the authenticated caller and is pinned server-side from the request
-(session cookie by default; pass the authorization header in node.js).
+(session cookie by default; pass the authorization header in node.js). The optional
+`user` field (`"type:id"`, or a bare id treated as `"user:<id>"`) lets you check on
+behalf of someone else, but the server honors it only for super-admin callers or when
+it equals the caller's own token subject — anything else is rejected, never silently
+ignored.
 
-**1. Check a single permission** — `fgaCheck` answers "does the caller have `relation`
-on `object`?".
+**1. Check permissions** — `checkPermissions` answers "does the subject have
+`relation` on `object`?" for one or more pairs in a single round trip. `results`
+come back in the same order as the supplied `checks`, each echoing its
+relation/object pair.
 
 ```js
-const { data } = await authRef.fgaCheck(
-  { relation: 'can_view', object: 'document:1' },
+const { data } = await authRef.checkPermissions(
+  { checks: [{ relation: 'can_view', object: 'document:1' }] },
   { Authorization: `Bearer ${token}` }, // omit in the browser to use the cookie
 );
 
-if (data?.allowed) {
+if (data?.results?.[0]?.allowed) {
   // caller may view document:1
 }
 ```
 
-**2. Check many at once** — `fgaBatchCheck` evaluates several pairs in one round trip;
-`results` come back in the same order as the supplied `checks`.
+Batch several checks at once:
 
 ```js
-const { data } = await authRef.fgaBatchCheck({
+const { data } = await authRef.checkPermissions({
   checks: [
     { relation: 'can_view', object: 'document:1' },
     { relation: 'can_edit', object: 'document:1' },
   ],
 });
-// data?.results => [{ allowed: true }, { allowed: false }]
+// data?.results =>
+//   [
+//     { relation: 'can_view', object: 'document:1', allowed: true },
+//     { relation: 'can_edit', object: 'document:1', allowed: false },
+//   ]
 ```
 
-**3. List accessible objects** — `fgaListObjects` returns the ids of every object of a
-type the caller relates to (handy for filtering a list to what the user can see).
+**2. List accessible objects** — `listPermissions` returns the ids of every object of
+a type the subject relates to (handy for filtering a list to what the user can see).
 
 ```js
-const { data } = await authRef.fgaListObjects({
+const { data } = await authRef.listPermissions({
   relation: 'can_view',
   object_type: 'document',
 });

--- a/__test__/index.test.ts
+++ b/__test__/index.test.ts
@@ -194,12 +194,12 @@ describe('Integration Tests - authorizer-js', () => {
   // ---- Fine-grained authorization (FGA) ----
   //
   // The embedded OpenFGA engine auto-enables when the main database is
-  // SQL-compatible (this container runs sqlite), so the fga_* surface is live
-  // out of the box on FGA-capable servers. Older server images predate the
-  // fga_* GraphQL fields entirely; the probe in the setup test detects that
-  // and the FGA assertions no-op with a warning instead of failing — they
-  // light up automatically once AUTHORIZER_IMAGE points at an FGA-capable
-  // build.
+  // SQL-compatible (this container runs sqlite), so the permission-check
+  // surface is live out of the box on FGA-capable servers. Older server
+  // images predate the check_permissions / list_permissions GraphQL fields
+  // entirely; the probe in the setup test detects that and the FGA assertions
+  // no-op with a warning instead of failing — they light up automatically
+  // once AUTHORIZER_IMAGE points at an FGA-capable build.
   //
   // Model/tuple authoring is an admin concern and deliberately NOT part of
   // the SDK surface; the setup below uses the raw `graphqlQuery` escape hatch
@@ -218,19 +218,19 @@ type document
 
   const fgaSkipWarning = () =>
     console.warn(
-      'Skipping FGA assertions: server image has no fga_* GraphQL surface. Set AUTHORIZER_IMAGE to an FGA-capable build to run them.',
+      'Skipping FGA assertions: server image has no check_permissions GraphQL surface. Set AUTHORIZER_IMAGE to an FGA-capable build to run them.',
     );
 
   it('should install an FGA model and grant a tuple (admin setup)', async () => {
     expect(loginRes?.data?.access_token).toBeDefined();
     expect(loginRes?.data?.access_token).not.toBeNull();
 
-    // Probe: a server without FGA fails GraphQL validation on the fga_check
-    // field ("Cannot query field"); any other outcome (data or an engine /
-    // auth error) proves the surface exists.
+    // Probe: a server without FGA fails GraphQL validation on the
+    // check_permissions field ("Cannot query field"); any other outcome (data
+    // or an engine / auth error) proves the surface exists.
     const probe = await authorizer.graphqlQuery({
       query:
-        'query fgaProbe { fga_check(params: { relation: "viewer", object: "document:probe" }) { allowed } }',
+        'query fgaProbe { check_permissions(params: { checks: [{ relation: "viewer", object: "document:probe" }] }) { results { allowed } } }',
       headers: { Authorization: `Bearer ${loginRes?.data?.access_token}` },
       operationName: 'fgaProbe',
     });
@@ -287,54 +287,64 @@ type document
     expect(tuplesRes?.errors).toHaveLength(0);
   });
 
-  it('should allow fgaCheck for a granted relation and deny otherwise', async () => {
+  it('should allow checkPermissions for a granted relation and deny otherwise', async () => {
     if (!fgaSupported) return fgaSkipWarning();
     const authHeaders = {
       Authorization: `Bearer ${loginRes?.data?.access_token}`,
     };
 
     // can_view derives from the granted viewer tuple.
-    const allowedRes = await authorizer.fgaCheck(
-      { relation: 'can_view', object: 'document:fga-doc-1' },
+    const allowedRes = await authorizer.checkPermissions(
+      { checks: [{ relation: 'can_view', object: 'document:fga-doc-1' }] },
       authHeaders,
     );
     expect(allowedRes?.errors).toHaveLength(0);
-    expect(allowedRes?.data?.allowed).toEqual(true);
+    expect(allowedRes?.data?.results).toHaveLength(1);
+    expect(allowedRes?.data?.results?.[0]).toEqual({
+      relation: 'can_view',
+      object: 'document:fga-doc-1',
+      allowed: true,
+    });
 
     // Nothing grants doc-2 — a clean deny (allowed=false), not an error.
-    const deniedRes = await authorizer.fgaCheck(
-      { relation: 'can_view', object: 'document:fga-doc-2' },
+    const deniedRes = await authorizer.checkPermissions(
+      { checks: [{ relation: 'can_view', object: 'document:fga-doc-2' }] },
       authHeaders,
     );
     expect(deniedRes?.errors).toHaveLength(0);
-    expect(deniedRes?.data?.allowed).toEqual(false);
+    expect(deniedRes?.data?.results).toHaveLength(1);
+    expect(deniedRes?.data?.results?.[0]?.allowed).toEqual(false);
   });
 
-  it('should honor contextual tuples in fgaCheck', async () => {
+  it('should honor contextual tuples in checkPermissions', async () => {
     if (!fgaSupported) return fgaSkipWarning();
     // The contextual tuple grants viewer on doc-2 for this single evaluation
     // only; nothing is persisted.
-    const res = await authorizer.fgaCheck(
+    const res = await authorizer.checkPermissions(
       {
-        relation: 'can_view',
-        object: 'document:fga-doc-2',
-        contextual_tuples: [
+        checks: [
           {
-            user: `user:${testConfig.userId}`,
-            relation: 'viewer',
+            relation: 'can_view',
             object: 'document:fga-doc-2',
+            contextual_tuples: [
+              {
+                user: `user:${testConfig.userId}`,
+                relation: 'viewer',
+                object: 'document:fga-doc-2',
+              },
+            ],
           },
         ],
       },
       { Authorization: `Bearer ${loginRes?.data?.access_token}` },
     );
     expect(res?.errors).toHaveLength(0);
-    expect(res?.data?.allowed).toEqual(true);
+    expect(res?.data?.results?.[0]?.allowed).toEqual(true);
   });
 
-  it('should return positional results from fgaBatchCheck', async () => {
+  it('should return positional results from a batched checkPermissions', async () => {
     if (!fgaSupported) return fgaSkipWarning();
-    const res = await authorizer.fgaBatchCheck(
+    const res = await authorizer.checkPermissions(
       {
         checks: [
           { relation: 'can_view', object: 'document:fga-doc-1' },
@@ -345,13 +355,22 @@ type document
     );
     expect(res?.errors).toHaveLength(0);
     expect(res?.data?.results).toHaveLength(2);
-    expect(res?.data?.results?.[0]?.allowed).toEqual(true);
-    expect(res?.data?.results?.[1]?.allowed).toEqual(false);
+    // Results are positional and echo the checked pair.
+    expect(res?.data?.results?.[0]).toEqual({
+      relation: 'can_view',
+      object: 'document:fga-doc-1',
+      allowed: true,
+    });
+    expect(res?.data?.results?.[1]).toEqual({
+      relation: 'can_view',
+      object: 'document:fga-doc-2',
+      allowed: false,
+    });
   });
 
-  it('should list accessible objects via fgaListObjects', async () => {
+  it('should list accessible objects via listPermissions', async () => {
     if (!fgaSupported) return fgaSkipWarning();
-    const res = await authorizer.fgaListObjects(
+    const res = await authorizer.listPermissions(
       { relation: 'can_view', object_type: 'document' },
       { Authorization: `Bearer ${loginRes?.data?.access_token}` },
     );

--- a/__test__/index.test.ts
+++ b/__test__/index.test.ts
@@ -181,6 +181,31 @@ describe('Integration Tests - authorizer-js', () => {
     expect(validateRes?.data?.is_valid).toEqual(true);
   });
 
+  it('should mark token invalid when required_permissions are missing', async () => {
+    expect(loginRes?.data?.access_token).toBeDefined();
+    expect(loginRes?.data?.access_token).not.toBeNull();
+    // A new user lacks the documents:read permission, so asserting it via
+    // required_permissions (AND semantics) must mark the token as not valid.
+    const validateRes = await authorizer.validateJWTToken({
+      token_type: 'access_token',
+      token: loginRes?.data?.access_token || '',
+      required_permissions: [{ resource: 'documents', scope: 'read' }],
+    });
+    expect(validateRes?.errors).toHaveLength(0);
+    expect(validateRes?.data?.is_valid).toEqual(false);
+  });
+
+  it('should fetch permissions for the authenticated user', async () => {
+    expect(loginRes?.data?.access_token).toBeDefined();
+    expect(loginRes?.data?.access_token).not.toBeNull();
+    const permissionsRes = await authorizer.getPermissions({
+      Authorization: `Bearer ${loginRes?.data?.access_token}`,
+    });
+    expect(permissionsRes?.errors).toHaveLength(0);
+    // A freshly signed up user has no fine-grained permissions assigned.
+    expect(permissionsRes?.data).toEqual([]);
+  });
+
   it('should update profile successfully', async () => {
     expect(loginRes?.data?.access_token).toBeDefined();
     expect(loginRes?.data?.access_token).not.toBeNull();

--- a/__test__/index.test.ts
+++ b/__test__/index.test.ts
@@ -80,7 +80,11 @@ describe('Integration Tests - authorizer-js', () => {
   beforeAll(async () => {
     const { args, clientId } = buildAuthorizerCliArgs();
 
-    container = await new GenericContainer('lakhansamani/authorizer:2.0.0-rc.6')
+    // Override with AUTHORIZER_IMAGE to test against a different server build
+    // (e.g. a locally built image with newer GraphQL surface).
+    container = await new GenericContainer(
+      process.env.AUTHORIZER_IMAGE || 'lakhansamani/authorizer:2.0.0-rc.6',
+    )
       .withCommand(args)
       .withExposedPorts(8080)
       .withWaitStrategy(Wait.forHttp('/health', 8080).forStatusCode(200))
@@ -100,7 +104,13 @@ describe('Integration Tests - authorizer-js', () => {
     )}/app`;
     authorizerConfig.clientID = clientId;
     console.log('Authorizer URL:', authorizerConfig.authorizerURL);
-    authorizer = new Authorizer(authorizerConfig);
+    authorizer = new Authorizer({
+      ...authorizerConfig,
+      // Node sends no implicit Origin header; newer server builds enforce
+      // CSRF on state-changing requests (Origin must match the server host).
+      // Browsers set this automatically, so this only affects node tests.
+      extraHeaders: { Origin: authorizerConfig.authorizerURL },
+    });
   });
 
   afterAll(async () => {
@@ -181,29 +191,172 @@ describe('Integration Tests - authorizer-js', () => {
     expect(validateRes?.data?.is_valid).toEqual(true);
   });
 
-  it('should mark token invalid when required_permissions are missing', async () => {
-    expect(loginRes?.data?.access_token).toBeDefined();
-    expect(loginRes?.data?.access_token).not.toBeNull();
-    // A new user lacks the documents:read permission, so asserting it via
-    // required_permissions (AND semantics) must mark the token as not valid.
-    const validateRes = await authorizer.validateJWTToken({
-      token_type: 'access_token',
-      token: loginRes?.data?.access_token || '',
-      required_permissions: [{ resource: 'documents', scope: 'read' }],
-    });
-    expect(validateRes?.errors).toHaveLength(0);
-    expect(validateRes?.data?.is_valid).toEqual(false);
-  });
+  // ---- Fine-grained authorization (FGA) ----
+  //
+  // The embedded OpenFGA engine auto-enables when the main database is
+  // SQL-compatible (this container runs sqlite), so the fga_* surface is live
+  // out of the box on FGA-capable servers. Older server images predate the
+  // fga_* GraphQL fields entirely; the probe in the setup test detects that
+  // and the FGA assertions no-op with a warning instead of failing — they
+  // light up automatically once AUTHORIZER_IMAGE points at an FGA-capable
+  // build.
+  //
+  // Model/tuple authoring is an admin concern and deliberately NOT part of
+  // the SDK surface; the setup below uses the raw `graphqlQuery` escape hatch
+  // with the admin secret, mirroring how the dashboard drives the `_fga_*`
+  // admin API.
+  let fgaSupported = false;
 
-  it('should fetch permissions for the authenticated user', async () => {
+  const fgaModelDsl = `model
+  schema 1.1
+type user
+type document
+  relations
+    define viewer: [user]
+    define can_view: viewer
+`;
+
+  const fgaSkipWarning = () =>
+    console.warn(
+      'Skipping FGA assertions: server image has no fga_* GraphQL surface. Set AUTHORIZER_IMAGE to an FGA-capable build to run them.',
+    );
+
+  it('should install an FGA model and grant a tuple (admin setup)', async () => {
     expect(loginRes?.data?.access_token).toBeDefined();
     expect(loginRes?.data?.access_token).not.toBeNull();
-    const permissionsRes = await authorizer.getPermissions({
+
+    // Probe: a server without FGA fails GraphQL validation on the fga_check
+    // field ("Cannot query field"); any other outcome (data or an engine /
+    // auth error) proves the surface exists.
+    const probe = await authorizer.graphqlQuery({
+      query:
+        'query fgaProbe { fga_check(params: { relation: "viewer", object: "document:probe" }) { allowed } }',
+      headers: { Authorization: `Bearer ${loginRes?.data?.access_token}` },
+      operationName: 'fgaProbe',
+    });
+    fgaSupported = !probe?.errors?.some((e) =>
+      e?.message?.includes('Cannot query field'),
+    );
+    if (!fgaSupported) {
+      fgaSkipWarning();
+      return;
+    }
+
+    const adminHeaders = {
+      'x-authorizer-admin-secret': authorizerConfig.adminSecret,
+    };
+
+    // Install a minimal model: viewer is granted directly, can_view derives
+    // from it.
+    const modelRes = await authorizer.graphqlQuery({
+      query:
+        'mutation fgaWriteModel($params: FgaWriteModelInput!) { _fga_write_model(params: $params) { id dsl } }',
+      variables: { params: { dsl: fgaModelDsl } },
+      headers: adminHeaders,
+      operationName: 'fgaWriteModel',
+    });
+    expect(modelRes?.errors).toHaveLength(0);
+    expect(modelRes?.data?._fga_write_model?.id).toBeDefined();
+
+    // The runtime checks pin the subject to the caller's token sub (the user
+    // id), so the granted tuple must reference it.
+    const profileRes = await authorizer.getProfile({
       Authorization: `Bearer ${loginRes?.data?.access_token}`,
     });
-    expect(permissionsRes?.errors).toHaveLength(0);
-    // A freshly signed up user has no fine-grained permissions assigned.
-    expect(permissionsRes?.data).toEqual([]);
+    expect(profileRes?.errors).toHaveLength(0);
+    testConfig.userId = profileRes?.data?.id || '';
+    expect(testConfig.userId.length).toBeGreaterThan(0);
+
+    const tuplesRes = await authorizer.graphqlQuery({
+      query:
+        'mutation fgaWriteTuples($params: FgaWriteTuplesInput!) { _fga_write_tuples(params: $params) { message } }',
+      variables: {
+        params: {
+          tuples: [
+            {
+              user: `user:${testConfig.userId}`,
+              relation: 'viewer',
+              object: 'document:fga-doc-1',
+            },
+          ],
+        },
+      },
+      headers: adminHeaders,
+      operationName: 'fgaWriteTuples',
+    });
+    expect(tuplesRes?.errors).toHaveLength(0);
+  });
+
+  it('should allow fgaCheck for a granted relation and deny otherwise', async () => {
+    if (!fgaSupported) return fgaSkipWarning();
+    const authHeaders = {
+      Authorization: `Bearer ${loginRes?.data?.access_token}`,
+    };
+
+    // can_view derives from the granted viewer tuple.
+    const allowedRes = await authorizer.fgaCheck(
+      { relation: 'can_view', object: 'document:fga-doc-1' },
+      authHeaders,
+    );
+    expect(allowedRes?.errors).toHaveLength(0);
+    expect(allowedRes?.data?.allowed).toEqual(true);
+
+    // Nothing grants doc-2 — a clean deny (allowed=false), not an error.
+    const deniedRes = await authorizer.fgaCheck(
+      { relation: 'can_view', object: 'document:fga-doc-2' },
+      authHeaders,
+    );
+    expect(deniedRes?.errors).toHaveLength(0);
+    expect(deniedRes?.data?.allowed).toEqual(false);
+  });
+
+  it('should honor contextual tuples in fgaCheck', async () => {
+    if (!fgaSupported) return fgaSkipWarning();
+    // The contextual tuple grants viewer on doc-2 for this single evaluation
+    // only; nothing is persisted.
+    const res = await authorizer.fgaCheck(
+      {
+        relation: 'can_view',
+        object: 'document:fga-doc-2',
+        contextual_tuples: [
+          {
+            user: `user:${testConfig.userId}`,
+            relation: 'viewer',
+            object: 'document:fga-doc-2',
+          },
+        ],
+      },
+      { Authorization: `Bearer ${loginRes?.data?.access_token}` },
+    );
+    expect(res?.errors).toHaveLength(0);
+    expect(res?.data?.allowed).toEqual(true);
+  });
+
+  it('should return positional results from fgaBatchCheck', async () => {
+    if (!fgaSupported) return fgaSkipWarning();
+    const res = await authorizer.fgaBatchCheck(
+      {
+        checks: [
+          { relation: 'can_view', object: 'document:fga-doc-1' },
+          { relation: 'can_view', object: 'document:fga-doc-2' },
+        ],
+      },
+      { Authorization: `Bearer ${loginRes?.data?.access_token}` },
+    );
+    expect(res?.errors).toHaveLength(0);
+    expect(res?.data?.results).toHaveLength(2);
+    expect(res?.data?.results?.[0]?.allowed).toEqual(true);
+    expect(res?.data?.results?.[1]?.allowed).toEqual(false);
+  });
+
+  it('should list accessible objects via fgaListObjects', async () => {
+    if (!fgaSupported) return fgaSkipWarning();
+    const res = await authorizer.fgaListObjects(
+      { relation: 'can_view', object_type: 'document' },
+      { Authorization: `Bearer ${loginRes?.data?.access_token}` },
+    );
+    expect(res?.errors).toHaveLength(0);
+    expect(res?.data?.objects).toEqual(['document:fga-doc-1']);
   });
 
   it('should update profile successfully', async () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -245,6 +245,27 @@ export class Authorizer {
     }
   };
 
+  // fetch the fine-grained resource:scope permissions granted to the
+  // authenticated principal. Uses the session cookie by default; when running
+  // in node.js pass the authorization header.
+  getPermissions = async (
+    headers?: Types.Headers,
+  ): Promise<Types.ApiResponse<Types.Permission[]>> => {
+    try {
+      const res = await this.graphqlQuery({
+        query: 'query permissions { permissions { resource scope } }',
+        headers,
+        operationName: 'permissions',
+      });
+
+      return res?.errors?.length
+        ? this.errorResponse(res.errors)
+        : this.okResponse(res.data?.permissions);
+    } catch (error) {
+      return this.errorResponse([error]);
+    }
+  };
+
   // this is used to verify / get session using cookie by default. If using node.js pass authorization header
   getSession = async (
     headers?: Types.Headers,

--- a/src/index.ts
+++ b/src/index.ts
@@ -245,22 +245,71 @@ export class Authorizer {
     }
   };
 
-  // fetch the fine-grained resource:scope permissions granted to the
-  // authenticated principal. Uses the session cookie by default; when running
-  // in node.js pass the authorization header.
-  getPermissions = async (
+  // fgaCheck answers "does the caller have `relation` on `object`?" using the
+  // embedded OpenFGA engine. The subject is pinned server-side from the request
+  // (session cookie by default; pass the authorization header in node.js).
+  fgaCheck = async (
+    params: Types.FgaCheckInput,
     headers?: Types.Headers,
-  ): Promise<Types.ApiResponse<Types.Permission[]>> => {
+  ): Promise<Types.ApiResponse<Types.FgaCheckResponse>> => {
     try {
       const res = await this.graphqlQuery({
-        query: 'query permissions { permissions { resource scope } }',
+        query:
+          'query fgaCheck($params: FgaCheckInput!){ fga_check(params: $params) { allowed } }',
         headers,
-        operationName: 'permissions',
+        variables: { params },
+        operationName: 'fgaCheck',
       });
 
       return res?.errors?.length
         ? this.errorResponse(res.errors)
-        : this.okResponse(res.data?.permissions);
+        : this.okResponse(res.data?.fga_check);
+    } catch (error) {
+      return this.errorResponse([error]);
+    }
+  };
+
+  // fgaBatchCheck evaluates several relation/object pairs in one round trip.
+  // Results are returned in the same order as the supplied `checks`.
+  fgaBatchCheck = async (
+    params: Types.FgaBatchCheckInput,
+    headers?: Types.Headers,
+  ): Promise<Types.ApiResponse<Types.FgaBatchCheckResponse>> => {
+    try {
+      const res = await this.graphqlQuery({
+        query:
+          'query fgaBatchCheck($params: FgaBatchCheckInput!){ fga_batch_check(params: $params) { results { allowed } } }',
+        headers,
+        variables: { params },
+        operationName: 'fgaBatchCheck',
+      });
+
+      return res?.errors?.length
+        ? this.errorResponse(res.errors)
+        : this.okResponse(res.data?.fga_batch_check);
+    } catch (error) {
+      return this.errorResponse([error]);
+    }
+  };
+
+  // fgaListObjects returns the fully-qualified ids of objects of `object_type`
+  // the caller relates to via `relation`.
+  fgaListObjects = async (
+    params: Types.FgaListObjectsInput,
+    headers?: Types.Headers,
+  ): Promise<Types.ApiResponse<Types.FgaListObjectsResponse>> => {
+    try {
+      const res = await this.graphqlQuery({
+        query:
+          'query fgaListObjects($params: FgaListObjectsInput!){ fga_list_objects(params: $params) { objects } }',
+        headers,
+        variables: { params },
+        operationName: 'fgaListObjects',
+      });
+
+      return res?.errors?.length
+        ? this.errorResponse(res.errors)
+        : this.okResponse(res.data?.fga_list_objects);
     } catch (error) {
       return this.errorResponse([error]);
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -245,71 +245,59 @@ export class Authorizer {
     }
   };
 
-  // fgaCheck answers "does the caller have `relation` on `object`?" using the
-  // embedded OpenFGA engine. The subject is pinned server-side from the request
-  // (session cookie by default; pass the authorization header in node.js).
-  fgaCheck = async (
-    params: Types.FgaCheckInput,
+  // checkPermissions evaluates one or more permission checks ("does the
+  // subject have `relation` on `object`?") in a single round trip using the
+  // embedded OpenFGA engine. Results come back in the same order as the
+  // supplied `checks`, each echoing its relation/object pair.
+  //
+  // The subject defaults to the authenticated caller and is pinned server-side
+  // from the request (session cookie by default; pass the authorization header
+  // in node.js). The optional `params.user` ("type:id", or a bare id treated
+  // as "user:<id>") is honored only for super-admin callers or when it equals
+  // the caller's own token subject; anything else is rejected by the server.
+  checkPermissions = async (
+    params: Types.CheckPermissionsInput,
     headers?: Types.Headers,
-  ): Promise<Types.ApiResponse<Types.FgaCheckResponse>> => {
+  ): Promise<Types.ApiResponse<Types.CheckPermissionsResponse>> => {
     try {
       const res = await this.graphqlQuery({
         query:
-          'query fgaCheck($params: FgaCheckInput!){ fga_check(params: $params) { allowed } }',
+          'query checkPermissions($params: CheckPermissionsInput!){ check_permissions(params: $params) { results { relation object allowed } } }',
         headers,
         variables: { params },
-        operationName: 'fgaCheck',
+        operationName: 'checkPermissions',
       });
 
       return res?.errors?.length
         ? this.errorResponse(res.errors)
-        : this.okResponse(res.data?.fga_check);
+        : this.okResponse(res.data?.check_permissions);
     } catch (error) {
       return this.errorResponse([error]);
     }
   };
 
-  // fgaBatchCheck evaluates several relation/object pairs in one round trip.
-  // Results are returned in the same order as the supplied `checks`.
-  fgaBatchCheck = async (
-    params: Types.FgaBatchCheckInput,
+  // listPermissions returns the fully-qualified ids of objects of
+  // `object_type` the subject holds `relation` on (handy for filtering a list
+  // to what the user can see). Subject resolution follows the same rules as
+  // checkPermissions: it defaults to the authenticated caller, and the
+  // optional `params.user` override is honored only for super-admin callers
+  // or when it equals the caller's own token subject.
+  listPermissions = async (
+    params: Types.ListPermissionsInput,
     headers?: Types.Headers,
-  ): Promise<Types.ApiResponse<Types.FgaBatchCheckResponse>> => {
+  ): Promise<Types.ApiResponse<Types.ListPermissionsResponse>> => {
     try {
       const res = await this.graphqlQuery({
         query:
-          'query fgaBatchCheck($params: FgaBatchCheckInput!){ fga_batch_check(params: $params) { results { allowed } } }',
+          'query listPermissions($params: ListPermissionsInput!){ list_permissions(params: $params) { objects } }',
         headers,
         variables: { params },
-        operationName: 'fgaBatchCheck',
+        operationName: 'listPermissions',
       });
 
       return res?.errors?.length
         ? this.errorResponse(res.errors)
-        : this.okResponse(res.data?.fga_batch_check);
-    } catch (error) {
-      return this.errorResponse([error]);
-    }
-  };
-
-  // fgaListObjects returns the fully-qualified ids of objects of `object_type`
-  // the caller relates to via `relation`.
-  fgaListObjects = async (
-    params: Types.FgaListObjectsInput,
-    headers?: Types.Headers,
-  ): Promise<Types.ApiResponse<Types.FgaListObjectsResponse>> => {
-    try {
-      const res = await this.graphqlQuery({
-        query:
-          'query fgaListObjects($params: FgaListObjectsInput!){ fga_list_objects(params: $params) { objects } }',
-        headers,
-        variables: { params },
-        operationName: 'fgaListObjects',
-      });
-
-      return res?.errors?.length
-        ? this.errorResponse(res.errors)
-        : this.okResponse(res.data?.fga_list_objects);
+        : this.okResponse(res.data?.list_permissions);
     } catch (error) {
       return this.errorResponse([error]);
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -293,7 +293,9 @@ export interface DeleteUserRequest {
 //
 // For every operation the subject defaults to the authenticated caller and is
 // pinned server-side from the request (session cookie or bearer token). The
-// optional `user` override is honored only for super-admin callers.
+// optional `user` override ("type:id", or a bare id treated as "user:<id>")
+// is honored only when the caller is a super-admin or when it equals the
+// caller's own token subject; anything else is rejected by the server.
 
 // FgaTupleInput is a single relationship tuple (user is related to object via
 // relation), used to pass contextual tuples evaluated for one check only and
@@ -304,41 +306,52 @@ export interface FgaTupleInput {
   object: string;
 }
 
-// FgaCheckInput asks "is the caller related to `object` via `relation`?".
-export interface FgaCheckInput {
+// PermissionCheckInput is one permission to evaluate: "does the subject have
+// `relation` on `object`?". Contextual tuples are evaluated for this check
+// only and never persisted.
+export interface PermissionCheckInput {
   relation: string;
   object: string;
   contextual_tuples?: FgaTupleInput[] | null;
+}
+
+// CheckPermissionsInput evaluates one or more permission checks in a single
+// call. The subject defaults to the authenticated caller (JWT / session
+// cookie). The optional `user` ("type:id", or a bare id treated as
+// "user:<id>") is honored only when the caller is a super-admin OR it equals
+// the caller's own token subject; anything else is rejected by the server —
+// never silently ignored.
+export interface CheckPermissionsInput {
+  checks: PermissionCheckInput[];
   user?: string | null;
 }
 
-// FgaCheckResponse is the result of a single relationship check.
-export interface FgaCheckResponse {
+// PermissionCheckResult is the outcome of one permission check, echoing the
+// checked pair so batch results are self-describing (and positionally aligned
+// with the supplied `checks`).
+export interface PermissionCheckResult {
+  relation: string;
+  object: string;
   allowed: boolean;
 }
 
-// FgaBatchCheckInput evaluates multiple relation/object pairs in one call.
-export interface FgaBatchCheckInput {
-  checks: FgaCheckInput[];
+// CheckPermissionsResponse carries one result per supplied check, in order.
+export interface CheckPermissionsResponse {
+  results: PermissionCheckResult[];
 }
 
-// FgaBatchCheckResponse holds the results of a batch check, positionally
-// aligned with the `checks` supplied in the request.
-export interface FgaBatchCheckResponse {
-  results: FgaCheckResponse[];
-}
-
-// FgaListObjectsInput enumerates objects of `object_type` the caller relates to
-// via `relation`.
-export interface FgaListObjectsInput {
+// ListPermissionsInput enumerates the objects of `object_type` the subject
+// holds `relation` on. Subject resolution (the optional `user` override)
+// follows the same rules as CheckPermissionsInput.user.
+export interface ListPermissionsInput {
   relation: string;
   object_type: string;
   user?: string | null;
 }
 
-// FgaListObjectsResponse lists fully-qualified object ids (e.g. "document:1")
-// the caller relates to.
-export interface FgaListObjectsResponse {
+// ListPermissionsResponse lists fully-qualified object ids (e.g. "document:1")
+// the subject holds the queried permission on.
+export interface ListPermissionsResponse {
   objects: string[];
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -285,10 +285,27 @@ export interface DeleteUserRequest {
   email: string;
 }
 
+// Fine-grained authorization (FGA) types
+// PermissionInput is a resource:scope pair asserted as a required permission.
+// Required permissions are evaluated with AND semantics — every entry must be
+// granted, otherwise the principal is treated as unauthorized.
+export interface PermissionInput {
+  resource: string;
+  scope: string;
+}
+
+// Permission is a resource:scope permission granted to a principal,
+// returned by the permissions query.
+export interface Permission {
+  resource: string;
+  scope: string;
+}
+
 // SessionQueryRequest
 export interface SessionQueryRequest {
   roles?: string[] | null;
   scope?: string[] | null;
+  required_permissions?: PermissionInput[] | null;
 }
 
 // Keep SessionQueryInput as alias for backward compatibility
@@ -299,6 +316,7 @@ export interface ValidateJWTTokenRequest {
   token_type: string;
   token: string;
   roles?: string[] | null;
+  required_permissions?: PermissionInput[] | null;
 }
 
 // Keep ValidateJWTTokenInput as alias for backward compatibility
@@ -314,6 +332,7 @@ export interface ValidateJWTTokenResponse {
 export interface ValidateSessionRequest {
   cookie: string;
   roles?: string[] | null;
+  required_permissions?: PermissionInput[] | null;
 }
 
 // Keep ValidateSessionInput as alias for backward compatibility

--- a/src/types.ts
+++ b/src/types.ts
@@ -285,27 +285,67 @@ export interface DeleteUserRequest {
   email: string;
 }
 
-// Fine-grained authorization (FGA) types
-// PermissionInput is a resource:scope pair asserted as a required permission.
-// Required permissions are evaluated with AND semantics — every entry must be
-// granted, otherwise the principal is treated as unauthorized.
-export interface PermissionInput {
-  resource: string;
-  scope: string;
+// Fine-grained authorization (FGA) types — the client-facing surface of
+// Authorizer's embedded OpenFGA engine. Only the read-side operations a relying
+// party needs are exposed: checking access and listing accessible objects.
+// Authoring the authorization model and relationship tuples is an admin concern
+// handled from the dashboard / `_fga_*` admin API, and is not part of this SDK.
+//
+// For every operation the subject defaults to the authenticated caller and is
+// pinned server-side from the request (session cookie or bearer token). The
+// optional `user` override is honored only for super-admin callers.
+
+// FgaTupleInput is a single relationship tuple (user is related to object via
+// relation), used to pass contextual tuples evaluated for one check only and
+// never persisted.
+export interface FgaTupleInput {
+  user: string;
+  relation: string;
+  object: string;
 }
 
-// Permission is a resource:scope permission granted to a principal,
-// returned by the permissions query.
-export interface Permission {
-  resource: string;
-  scope: string;
+// FgaCheckInput asks "is the caller related to `object` via `relation`?".
+export interface FgaCheckInput {
+  relation: string;
+  object: string;
+  contextual_tuples?: FgaTupleInput[] | null;
+  user?: string | null;
+}
+
+// FgaCheckResponse is the result of a single relationship check.
+export interface FgaCheckResponse {
+  allowed: boolean;
+}
+
+// FgaBatchCheckInput evaluates multiple relation/object pairs in one call.
+export interface FgaBatchCheckInput {
+  checks: FgaCheckInput[];
+}
+
+// FgaBatchCheckResponse holds the results of a batch check, positionally
+// aligned with the `checks` supplied in the request.
+export interface FgaBatchCheckResponse {
+  results: FgaCheckResponse[];
+}
+
+// FgaListObjectsInput enumerates objects of `object_type` the caller relates to
+// via `relation`.
+export interface FgaListObjectsInput {
+  relation: string;
+  object_type: string;
+  user?: string | null;
+}
+
+// FgaListObjectsResponse lists fully-qualified object ids (e.g. "document:1")
+// the caller relates to.
+export interface FgaListObjectsResponse {
+  objects: string[];
 }
 
 // SessionQueryRequest
 export interface SessionQueryRequest {
   roles?: string[] | null;
   scope?: string[] | null;
-  required_permissions?: PermissionInput[] | null;
 }
 
 // Keep SessionQueryInput as alias for backward compatibility
@@ -316,7 +356,6 @@ export interface ValidateJWTTokenRequest {
   token_type: string;
   token: string;
   roles?: string[] | null;
-  required_permissions?: PermissionInput[] | null;
 }
 
 // Keep ValidateJWTTokenInput as alias for backward compatibility
@@ -332,7 +371,6 @@ export interface ValidateJWTTokenResponse {
 export interface ValidateSessionRequest {
   cookie: string;
   roles?: string[] | null;
-  required_permissions?: PermissionInput[] | null;
 }
 
 // Keep ValidateSessionInput as alias for backward compatibility


### PR DESCRIPTION
## Summary

Adds client-facing Fine-Grained Authorization (FGA) support to the JS SDK, mirroring the authorization API shipped on the Authorizer server. FGA was planned but not yet present in the SDK.

The server's FGA model is Keycloak-style (resources / scopes / policies / permissions). This PR wraps the two surfaces relevant to a **client** SDK; admin `_authz_*` CRUD is intentionally excluded to keep the SDK's client-only scope (it exposes no admin operations).

## Changes

- **`required_permissions`** (`PermissionInput[]`, AND semantics) added to `SessionQueryRequest`, `ValidateJWTTokenRequest`, and `ValidateSessionRequest`. If any required permission is denied, the result is unauthorized.
- **`getPermissions(headers)`** — new method wrapping the `permissions` query; returns the authenticated principal's granted `resource:scope` permissions.
- **`Permission` / `PermissionInput`** interfaces added to `types.ts`.
- Integration tests: missing-`required_permissions` marks token invalid, and `getPermissions` returns the user's permissions.
- README: new "Fine-grained authorization (FGA)" usage section.

## Verification

- `tsc --noEmit` ✅
- `eslint` ✅
- `npm run build` (tsup) ✅ — `getPermissions`, `Permission`, `PermissionInput`, `required_permissions` confirmed in emitted `index.d.ts`
- Integration tests (testcontainers) compile; they require Docker + a running FGA-enabled Authorizer to execute.