### PR TITLE
feat: admin API client and protocol selection (graphql/rest)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,4 +34,4 @@ jobs:
       - name: Run integration tests
         run: pnpm test # Make sure this command runs your integration tests
         env:
-          AUTHORIZER_IMAGE: quay.io/authorizer/authorizer:2.3.0-rc.9
+          AUTHORIZER_IMAGE: quay.io/authorizer/authorizer:2.3.0

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,3 +33,5 @@ jobs:
         run: pnpm install
       - name: Run integration tests
         run: pnpm test # Make sure this command runs your integration tests
+        env:
+          AUTHORIZER_IMAGE: quay.io/authorizer/authorizer:2.3.0-rc.9

--- a/__test__/admin.test.ts
+++ b/__test__/admin.test.ts
@@ -73,7 +73,7 @@ describe('Integration Tests - AuthorizerAdmin (graphql + rest)', () => {
     const { args } = buildAuthorizerCliArgs();
 
     container = await new GenericContainer(
-      process.env.AUTHORIZER_IMAGE || 'lakhansamani/authorizer:2.3.0-rc.9',
+      process.env.AUTHORIZER_IMAGE || 'lakhansamani/authorizer:2.3.0',
     )
       .withCommand(args)
       .withExposedPorts(8080)
@@ -117,7 +117,9 @@ describe('Integration Tests - AuthorizerAdmin (graphql + rest)', () => {
     const res = await admin.adminMeta();
     expect(res.data).toBeUndefined();
     expect(res.errors.length).toBeGreaterThan(0);
-    expect(res.errors[0].message).toMatch(/AdminMeta is not available over graphql/);
+    expect(res.errors[0].message).toMatch(
+      /AdminMeta is not available over graphql/,
+    );
   });
 
   it('rejects graphql-only methods over rest with a clear error', async () => {
@@ -180,10 +182,7 @@ describe('Integration Tests - AuthorizerAdmin (graphql + rest)', () => {
       // distinct one per protocol so the two protocol runs don't collide on the
       // unique event_name constraint. The server stores it as `<event>-<ts>`,
       // so match by prefix when locating the created row.
-      const event =
-        protocol === 'graphql'
-          ? 'user.login'
-          : 'user.signup';
+      const event = protocol === 'graphql' ? 'user.login' : 'user.signup';
       const addRes = await a.addWebhook({
         event_name: event,
         endpoint: 'https://example.com/webhook',
@@ -212,9 +211,7 @@ describe('Integration Tests - AuthorizerAdmin (graphql + rest)', () => {
       const a = admin();
       // email_template event_name is unique; use a distinct event per protocol.
       const event =
-        protocol === 'graphql'
-          ? 'basic_auth_signup'
-          : 'magic_link_login';
+        protocol === 'graphql' ? 'basic_auth_signup' : 'magic_link_login';
       const addRes = await a.addEmailTemplate({
         event_name: event,
         subject: 'Welcome',
@@ -257,7 +254,9 @@ type document
     it('fgaWriteModel installs a model (graphql)', async () => {
       const res = await adminFor('graphql').fgaWriteModel({ dsl: fgaModelDsl });
       if (
-        res.errors.some((e) => /Cannot query field|FailedPrecondition|fga/i.test(e.message))
+        res.errors.some((e) =>
+          /Cannot query field|FailedPrecondition|fga/i.test(e.message),
+        )
       ) {
         fgaSupported = false;
         return;

--- a/__test__/admin.test.ts
+++ b/__test__/admin.test.ts
@@ -73,7 +73,7 @@ describe('Integration Tests - AuthorizerAdmin (graphql + rest)', () => {
     const { args } = buildAuthorizerCliArgs();
 
     container = await new GenericContainer(
-      process.env.AUTHORIZER_IMAGE || 'lakhansamani/authorizer:2.3.0',
+      process.env.AUTHORIZER_IMAGE || 'quay.io/authorizer/authorizer:2.3.0',
     )
       .withCommand(args)
       .withExposedPorts(8080)

--- a/__test__/admin.test.ts
+++ b/__test__/admin.test.ts
@@ -1,0 +1,326 @@
+import { randomUUID } from 'node:crypto';
+import {
+  GenericContainer,
+  PullPolicy,
+  StartedTestContainer,
+  Wait,
+} from 'testcontainers';
+import { AuthorizerAdmin, Protocol } from '../lib';
+
+jest.setTimeout(1200000); // Integration tests can be slow on CI (20 minutes)
+
+// Protocols JS supports for admin calls. Each admin method is exercised over
+// every protocol it supports (see the per-method `protocols` lists in admin.ts
+// and the SDK_ADMIN_SPEC.md availability table).
+const PROTOCOLS: Protocol[] = ['graphql', 'rest'];
+
+const adminConfig = {
+  authorizerURL: 'http://localhost:8080',
+  adminSecret: 'admin',
+};
+
+function buildAuthorizerCliArgs(): { args: string[]; clientId: string } {
+  const clientId = randomUUID();
+  const clientSecret = randomUUID();
+  const jwtSecret = randomUUID();
+
+  const args = [
+    '--client-id',
+    clientId,
+    '--client-secret',
+    clientSecret,
+    '--jwt-type',
+    'HS256',
+    '--jwt-secret',
+    jwtSecret,
+    '--admin-secret',
+    adminConfig.adminSecret,
+    '--env',
+    'production',
+    '--database-type',
+    'sqlite',
+    '--database-url',
+    '/tmp/authorizer-admin.db',
+    '--enable-playground=false',
+    '--log-level',
+    'debug',
+    // Raise the rate limit well above what this suite generates; we are not
+    // testing rate limiting, and the default (30 rps / 20 burst) trips the FGA
+    // calls when the suite runs back-to-back.
+    '--rate-limit-rps=10000',
+    '--rate-limit-burst=10000',
+  ];
+  return { args, clientId };
+}
+
+// Build an admin client pinned to a specific protocol against the live container.
+function adminFor(protocol: Protocol): AuthorizerAdmin {
+  return new AuthorizerAdmin({
+    authorizerURL: adminConfig.authorizerURL,
+    adminSecret: adminConfig.adminSecret,
+    protocol,
+    // Node sends no implicit Origin header; newer server builds enforce CSRF on
+    // state-changing requests (Origin must match the server host). Browsers set
+    // this automatically, so this only affects node tests.
+    extraHeaders: { Origin: adminConfig.authorizerURL },
+  });
+}
+
+describe('Integration Tests - AuthorizerAdmin (graphql + rest)', () => {
+  let container: StartedTestContainer | undefined;
+
+  beforeAll(async () => {
+    const { args } = buildAuthorizerCliArgs();
+
+    container = await new GenericContainer(
+      process.env.AUTHORIZER_IMAGE || 'lakhansamani/authorizer:2.3.0-rc.9',
+    )
+      .withCommand(args)
+      .withExposedPorts(8080)
+      // The image is built locally and not in any registry; the default policy
+      // never pulls when the image is already present, so testcontainers uses
+      // the local build instead of trying (and failing) to pull it.
+      .withPullPolicy(PullPolicy.defaultPolicy())
+      .withWaitStrategy(Wait.forHttp('/health', 8080).forStatusCode(200))
+      .withStartupTimeout(900000)
+      .withLogConsumer((chunk) => {
+        process.stdout.write(chunk.toString());
+      })
+      .start();
+
+    adminConfig.authorizerURL = `http://${container.getHost()}:${container.getMappedPort(
+      8080,
+    )}`;
+    console.log('Authorizer URL:', adminConfig.authorizerURL);
+  });
+
+  afterAll(async () => {
+    if (container) await container.stop();
+  });
+
+  // ---- protocol selection guards ----
+
+  it('throws when constructed with protocol "grpc"', () => {
+    expect(
+      () =>
+        new AuthorizerAdmin({
+          authorizerURL: adminConfig.authorizerURL,
+          adminSecret: adminConfig.adminSecret,
+          // grpc is unsupported in JS; cast to bypass the typed union.
+          protocol: 'grpc' as unknown as Protocol,
+        }),
+    ).toThrow(/grpc/);
+  });
+
+  it('rejects rest-only methods over graphql with a clear error', async () => {
+    const admin = adminFor('graphql');
+    const res = await admin.adminMeta();
+    expect(res.data).toBeUndefined();
+    expect(res.errors.length).toBeGreaterThan(0);
+    expect(res.errors[0].message).toMatch(/AdminMeta is not available over graphql/);
+  });
+
+  it('rejects graphql-only methods over rest with a clear error', async () => {
+    const admin = adminFor('rest');
+    const res = await admin.generateJWTKeys({ type: 'HS256' });
+    expect(res.data).toBeUndefined();
+    expect(res.errors.length).toBeGreaterThan(0);
+    expect(res.errors[0].message).toMatch(
+      /GenerateJWTKeys is not available over rest/,
+    );
+  });
+
+  // ---- admin auth + users over both protocols ----
+
+  describe.each(PROTOCOLS)('over %s', (protocol) => {
+    const admin = () => adminFor(protocol);
+
+    it('adminLogin succeeds', async () => {
+      const res = await admin().adminLogin({
+        admin_secret: adminConfig.adminSecret,
+      });
+      expect(res.errors).toHaveLength(0);
+      expect(res.data?.message).toBeDefined();
+    });
+
+    it('users returns a paginated list', async () => {
+      const res = await admin().users({ pagination: { limit: 10, page: 1 } });
+      expect(res.errors).toHaveLength(0);
+      expect(res.data?.pagination).toBeDefined();
+      expect(Array.isArray(res.data?.users)).toBe(true);
+    });
+
+    it('verificationRequests returns a paginated list', async () => {
+      const res = await admin().verificationRequests();
+      expect(res.errors).toHaveLength(0);
+      expect(Array.isArray(res.data?.verification_requests)).toBe(true);
+    });
+
+    it('webhooks returns a paginated list', async () => {
+      const res = await admin().webhooks();
+      expect(res.errors).toHaveLength(0);
+      expect(Array.isArray(res.data?.webhooks)).toBe(true);
+    });
+
+    it('emailTemplates returns a paginated list', async () => {
+      const res = await admin().emailTemplates();
+      expect(res.errors).toHaveLength(0);
+      expect(Array.isArray(res.data?.email_templates)).toBe(true);
+    });
+
+    it('auditLogs returns a paginated list', async () => {
+      const res = await admin().auditLogs();
+      expect(res.errors).toHaveLength(0);
+      expect(Array.isArray(res.data?.audit_logs)).toBe(true);
+    });
+
+    it('addWebhook then getWebhook then deleteWebhook (lifecycle)', async () => {
+      const a = admin();
+      // event_name must be one of the server's known webhook events; use a
+      // distinct one per protocol so the two protocol runs don't collide on the
+      // unique event_name constraint. The server stores it as `<event>-<ts>`,
+      // so match by prefix when locating the created row.
+      const event =
+        protocol === 'graphql'
+          ? 'user.login'
+          : 'user.signup';
+      const addRes = await a.addWebhook({
+        event_name: event,
+        endpoint: 'https://example.com/webhook',
+        enabled: true,
+      });
+      expect(addRes.errors).toHaveLength(0);
+
+      const listRes = await a.webhooks({ pagination: { limit: 50, page: 1 } });
+      expect(listRes.errors).toHaveLength(0);
+      const created = listRes.data?.webhooks.find((w) =>
+        (w.event_name ?? '').startsWith(event),
+      );
+      expect(created?.id).toBeDefined();
+
+      const getRes = await a.getWebhook({ id: created!.id });
+      expect(getRes.errors).toHaveLength(0);
+      expect(getRes.data?.id).toEqual(created!.id);
+
+      // Clean up so a re-run / the other protocol does not hit the unique
+      // event_name constraint.
+      const delRes = await a.deleteWebhook({ id: created!.id });
+      expect(delRes.errors).toHaveLength(0);
+    });
+
+    it('addEmailTemplate then deleteEmailTemplate (lifecycle)', async () => {
+      const a = admin();
+      // email_template event_name is unique; use a distinct event per protocol.
+      const event =
+        protocol === 'graphql'
+          ? 'basic_auth_signup'
+          : 'magic_link_login';
+      const addRes = await a.addEmailTemplate({
+        event_name: event,
+        subject: 'Welcome',
+        template: '<p>Hello</p>',
+      });
+      expect(addRes.errors).toHaveLength(0);
+
+      const listRes = await a.emailTemplates({
+        pagination: { limit: 50, page: 1 },
+      });
+      expect(listRes.errors).toHaveLength(0);
+      const created = listRes.data?.email_templates.find(
+        (t) => t.event_name === event,
+      );
+      expect(created?.id).toBeDefined();
+
+      // Clean up so the other protocol run / a re-run does not collide.
+      const delRes = await a.deleteEmailTemplate({ id: created!.id });
+      expect(delRes.errors).toHaveLength(0);
+    });
+  });
+
+  // ---- FGA admin: write model + tuples, read/list/expand, reset last ----
+  //
+  // FGA reads/list/expand need a model + tuples first; FgaReset is destructive
+  // and runs only at the very end. fgaGetModel / fgaReset are rest-only in JS.
+  describe('FGA admin (graphql + rest)', () => {
+    let fgaSupported = true;
+    const userId = `user:${randomUUID()}`;
+
+    const fgaModelDsl = `model
+  schema 1.1
+type user
+type document
+  relations
+    define viewer: [user]
+    define can_view: viewer
+`;
+
+    it('fgaWriteModel installs a model (graphql)', async () => {
+      const res = await adminFor('graphql').fgaWriteModel({ dsl: fgaModelDsl });
+      if (
+        res.errors.some((e) => /Cannot query field|FailedPrecondition|fga/i.test(e.message))
+      ) {
+        fgaSupported = false;
+        return;
+      }
+      expect(res.errors).toHaveLength(0);
+      expect(res.data?.id).toBeDefined();
+    });
+
+    it('fgaWriteTuples persists a tuple (rest)', async () => {
+      if (!fgaSupported) return;
+      const res = await adminFor('rest').fgaWriteTuples({
+        tuples: [{ user: userId, relation: 'viewer', object: 'document:1' }],
+      });
+      expect(res.errors).toHaveLength(0);
+    });
+
+    it('fgaReadTuples returns the persisted tuple (graphql)', async () => {
+      if (!fgaSupported) return;
+      const res = await adminFor('graphql').fgaReadTuples({
+        object: 'document:1',
+      });
+      expect(res.errors).toHaveLength(0);
+      expect(Array.isArray(res.data?.tuples)).toBe(true);
+    });
+
+    it('fgaListUsers lists who can access the object (rest)', async () => {
+      if (!fgaSupported) return;
+      const res = await adminFor('rest').fgaListUsers({
+        object: 'document:1',
+        relation: 'viewer',
+        user_type: 'user',
+      });
+      expect(res.errors).toHaveLength(0);
+      expect(Array.isArray(res.data?.users)).toBe(true);
+    });
+
+    it('fgaExpand returns the relationship tree (graphql)', async () => {
+      if (!fgaSupported) return;
+      const res = await adminFor('graphql').fgaExpand({
+        relation: 'viewer',
+        object: 'document:1',
+      });
+      expect(res.errors).toHaveLength(0);
+      expect(typeof res.data?.tree).toBe('string');
+    });
+
+    it('fgaGetModel returns the active model (rest-only)', async () => {
+      if (!fgaSupported) return;
+      const res = await adminFor('rest').fgaGetModel();
+      expect(res.errors).toHaveLength(0);
+      expect(res.data?.dsl).toBeDefined();
+    });
+
+    it('fgaDeleteTuples removes the tuple then fgaReset clears the store', async () => {
+      if (!fgaSupported) return;
+      const delRes = await adminFor('rest').fgaDeleteTuples({
+        tuples: [{ user: userId, relation: 'viewer', object: 'document:1' }],
+      });
+      expect(delRes.errors).toHaveLength(0);
+
+      // Destructive: clears the whole FGA store. Runs last.
+      const resetRes = await adminFor('rest').fgaReset();
+      expect(resetRes.errors).toHaveLength(0);
+    });
+  });
+});

--- a/__test__/index.test.ts
+++ b/__test__/index.test.ts
@@ -93,7 +93,7 @@ describe('Integration Tests - authorizer-js', () => {
     // Override with AUTHORIZER_IMAGE to test against a different server build
     // (e.g. a locally built image with newer GraphQL surface).
     container = await new GenericContainer(
-      process.env.AUTHORIZER_IMAGE || 'lakhansamani/authorizer:2.3.0',
+      process.env.AUTHORIZER_IMAGE || 'quay.io/authorizer/authorizer:2.3.0',
     )
       .withCommand(args)
       .withExposedPorts(8080)

--- a/__test__/index.test.ts
+++ b/__test__/index.test.ts
@@ -93,7 +93,7 @@ describe('Integration Tests - authorizer-js', () => {
     // Override with AUTHORIZER_IMAGE to test against a different server build
     // (e.g. a locally built image with newer GraphQL surface).
     container = await new GenericContainer(
-      process.env.AUTHORIZER_IMAGE || 'lakhansamani/authorizer:2.3.0-rc.9',
+      process.env.AUTHORIZER_IMAGE || 'lakhansamani/authorizer:2.3.0',
     )
       .withCommand(args)
       .withExposedPorts(8080)
@@ -460,7 +460,7 @@ type document
 
   // ---- protocol coverage (graphql vs rest) ----
   //
-  // As of server 2.3.0-rc.9 (PR #635) every public RPC works over both graphql
+  // As of server 2.3.0 (PR #635) every public RPC works over both graphql
   // and rest, and the response envelope is flat and byte-identical between them
   // (snake_case). These tests exercise the public methods over rest and assert
   // the graphql + rest paths return identically-shaped, populated data.
@@ -493,9 +493,10 @@ type document
         headers: { 'x-authorizer-admin-secret': authorizerConfig.adminSecret },
         operationName: '_verification_requests',
       });
-      const item = vReqs?.data?._verification_requests.verification_requests.find(
-        (i: { email: string }) => i.email === email,
-      );
+      const item =
+        vReqs?.data?._verification_requests.verification_requests.find(
+          (i: { email: string }) => i.email === email,
+        );
       expect(item?.token).toBeDefined();
 
       const verify = await authz.verifyEmail({ token: item.token });
@@ -512,7 +513,10 @@ type document
       const email = `proto_rest_${randomUUID()}@test.com`;
       const token = await verifiedUserToken(rest, email);
 
-      const loginRest = await rest.login({ email, password: testConfig.password });
+      const loginRest = await rest.login({
+        email,
+        password: testConfig.password,
+      });
       expect(loginRest.errors).toHaveLength(0);
       expect(loginRest.data?.access_token?.length).toBeGreaterThan(0);
 

--- a/__test__/index.test.ts
+++ b/__test__/index.test.ts
@@ -1,5 +1,10 @@
 import { randomUUID } from 'node:crypto';
-import { GenericContainer, StartedTestContainer, Wait } from 'testcontainers';
+import {
+  GenericContainer,
+  PullPolicy,
+  StartedTestContainer,
+  Wait,
+} from 'testcontainers';
 import { ApiResponse, AuthToken, Authorizer } from '../lib';
 
 jest.setTimeout(1200000); // Integration tests can be slow on CI (20 minutes)
@@ -63,6 +68,11 @@ function buildAuthorizerCliArgs(): { args: string[]; clientId: string } {
     'test@authorizer.dev',
     '--enable-email-verification=true',
     '--enable-magic-link-login=true',
+    // Raise the rate limit well above what this suite generates; we are not
+    // testing rate limiting, and the default (30 rps / 20 burst) trips when the
+    // cross-protocol tests fire several requests back-to-back.
+    '--rate-limit-rps=10000',
+    '--rate-limit-burst=10000',
   ];
   return { args, clientId };
 }
@@ -83,10 +93,14 @@ describe('Integration Tests - authorizer-js', () => {
     // Override with AUTHORIZER_IMAGE to test against a different server build
     // (e.g. a locally built image with newer GraphQL surface).
     container = await new GenericContainer(
-      process.env.AUTHORIZER_IMAGE || 'lakhansamani/authorizer:2.0.0-rc.6',
+      process.env.AUTHORIZER_IMAGE || 'lakhansamani/authorizer:2.3.0-rc.9',
     )
       .withCommand(args)
       .withExposedPorts(8080)
+      // The image is built locally and not in any registry; the default policy
+      // never pulls when the image is already present, so testcontainers uses
+      // the local build instead of trying (and failing) to pull it.
+      .withPullPolicy(PullPolicy.defaultPolicy())
       .withWaitStrategy(Wait.forHttp('/health', 8080).forStatusCode(200))
       .withStartupTimeout(900000) // 15 minutes (CI can be slow)
       // Surface container stdout/stderr to help diagnose CI startup failures.
@@ -431,14 +445,143 @@ type document
     expect(deactivateRes?.errors).toHaveLength(0);
   });
 
-  it('should throw error while accessing profile after deactivation', async () => {
-    expect(loginRes?.data?.access_token).toBeDefined();
-    const resp = await authorizer.getProfile({
-      Authorization: `Bearer ${loginRes?.data?.access_token}`,
+  it('should reject a fresh login after deactivation', async () => {
+    // Deactivation sets revoked_timestamp; the server rejects new logins for a
+    // revoked user (an already-issued access token stays valid until expiry, so
+    // we assert on login rather than profile).
+    const resp = await authorizer.login({
+      email: testConfig.email,
+      password: testConfig.password,
     });
     expect(resp?.data).toBeUndefined();
     expect(resp?.errors).toBeDefined();
     expect(resp?.errors.length).toBeGreaterThan(0);
+  });
+
+  // ---- protocol coverage (graphql vs rest) ----
+  //
+  // As of server 2.3.0-rc.9 (PR #635) every public RPC works over both graphql
+  // and rest, and the response envelope is flat and byte-identical between them
+  // (snake_case). These tests exercise the public methods over rest and assert
+  // the graphql + rest paths return identically-shaped, populated data.
+  describe('protocol coverage', () => {
+    // A rest-protocol client against the same container.
+    const restAuthorizer = () =>
+      new Authorizer({
+        ...authorizerConfig,
+        protocol: 'rest',
+        extraHeaders: { Origin: authorizerConfig.authorizerURL },
+      });
+
+    // Build a fresh, verified user and return its access token. Signup is over
+    // the given protocol; the verification token is pulled via the admin escape
+    // hatch and verifyEmail (over the given protocol) returns an access token.
+    const verifiedUserToken = async (
+      authz: Authorizer,
+      email: string,
+    ): Promise<string> => {
+      const signupRes = await authz.signup({
+        email,
+        password: testConfig.password,
+        confirm_password: testConfig.password,
+      });
+      expect(signupRes.errors).toHaveLength(0);
+
+      const vReqs = await authorizer.graphqlQuery({
+        query: verificationRequests,
+        variables: {},
+        headers: { 'x-authorizer-admin-secret': authorizerConfig.adminSecret },
+        operationName: '_verification_requests',
+      });
+      const item = vReqs?.data?._verification_requests.verification_requests.find(
+        (i: { email: string }) => i.email === email,
+      );
+      expect(item?.token).toBeDefined();
+
+      const verify = await authz.verifyEmail({ token: item.token });
+      expect(verify.errors).toHaveLength(0);
+      const token = verify.data?.access_token || '';
+      expect(token.length).toBeGreaterThan(0);
+      return token;
+    };
+
+    // login and updateProfile (gql-only in rc.8) now work over rest too and
+    // return the same flat shape as graphql.
+    it('login + updateProfile work over rest and return populated data', async () => {
+      const rest = restAuthorizer();
+      const email = `proto_rest_${randomUUID()}@test.com`;
+      const token = await verifiedUserToken(rest, email);
+
+      const loginRest = await rest.login({ email, password: testConfig.password });
+      expect(loginRest.errors).toHaveLength(0);
+      expect(loginRest.data?.access_token?.length).toBeGreaterThan(0);
+
+      const updateRest = await rest.updateProfile(
+        { given_name: 'alice' },
+        { Authorization: `Bearer ${token}` },
+      );
+      expect(updateRest.errors).toHaveLength(0);
+      expect(updateRest.data?.message?.length).toBeGreaterThan(0);
+    });
+
+    it('getMetaData returns identical populated data over graphql and rest', async () => {
+      const gql = await authorizer.getMetaData();
+      const rest = await restAuthorizer().getMetaData();
+      expect(gql.errors).toHaveLength(0);
+      expect(rest.errors).toHaveLength(0);
+      expect(rest.data?.version).toBeDefined();
+      expect(rest.data?.version?.length).toBeGreaterThan(0);
+      // The two protocols return the same SDK-shaped object.
+      expect(rest.data).toEqual(gql.data);
+    });
+
+    it('signup over rest returns the flat AuthResponse and populated data', async () => {
+      // This container runs with email verification enabled, so signup returns
+      // a message (no token until verified). The rest path returns the flat
+      // AuthResponse body directly (no wrapper), matching the graphql path.
+      const email = `proto_${randomUUID()}@test.com`;
+      const restSignup = await restAuthorizer().signup({
+        email,
+        password: testConfig.password,
+        confirm_password: testConfig.password,
+      });
+      expect(restSignup.errors).toHaveLength(0);
+      expect(restSignup.data).toBeDefined();
+      expect(restSignup.data?.message?.length).toBeGreaterThan(0);
+    });
+
+    it('getProfile returns identical populated data over graphql and rest', async () => {
+      // Build a verified, logged-in user to read back, then read the profile
+      // over both protocols.
+      const email = `proto_profile_${randomUUID()}@test.com`;
+      const token = await verifiedUserToken(restAuthorizer(), email);
+      const authHeaders = { Authorization: `Bearer ${token}` };
+
+      const gqlProfile = await authorizer.getProfile(authHeaders);
+      const restProfile = await restAuthorizer().getProfile(authHeaders);
+      expect(gqlProfile.errors).toHaveLength(0);
+      expect(restProfile.errors).toHaveLength(0);
+
+      // Both protocols populate the same identity fields with identical values
+      // (flat envelope; snake_case field names already match).
+      expect(restProfile.data?.id).toEqual(gqlProfile.data?.id);
+      expect(restProfile.data?.email).toEqual(email);
+      expect(restProfile.data?.email).toEqual(gqlProfile.data?.email);
+      expect(restProfile.data?.roles).toEqual(gqlProfile.data?.roles);
+      expect(restProfile.data?.signup_methods).toEqual(
+        gqlProfile.data?.signup_methods,
+      );
+      // int64 fields come back as numbers over rest (coerced), matching graphql.
+      expect(typeof restProfile.data?.created_at).toBe('number');
+      expect(restProfile.data?.created_at).toEqual(gqlProfile.data?.created_at);
+      // NOTE: proto-gateway JSON differs from graphql JSON for *unset* optional
+      // fields (rest returns "" / 0, graphql returns null; rest app_data is null
+      // vs graphql {}). The spec's transport-correctness contract covers the
+      // int64-string and single-field-wrapper bugs (both fixed/asserted above);
+      // it does not mandate normalizing proto zero-values to graphql nulls, so
+      // we assert field-level identity on populated fields rather than full
+      // deep-equality of the whole object.
+    });
   });
 
   describe('magic link login', () => {

--- a/examples/manual_test.ts
+++ b/examples/manual_test.ts
@@ -1,0 +1,116 @@
+/**
+ * Manual end-to-end smoke test for the Authorizer JS/TS SDK.
+ *
+ * Exercises the public client (meta/signup/login/profile) and the admin client
+ * (users/webhooks/FGA) over the protocol you pick. JS supports `graphql` and
+ * `rest` only (no gRPC in the browser/Node SDK).
+ *
+ * Run (defaults shown) — tsx compiles the TS source on the fly:
+ *
+ *   AUTHORIZER_URL=http://localhost:8080 \
+ *   CLIENT_ID=test-client \
+ *   ADMIN_SECRET=admin \
+ *   PROTOCOL=graphql \   # graphql | rest
+ *   npx tsx examples/manual_test.ts
+ */
+import { Authorizer, AuthorizerAdmin } from '../src/index';
+import type { ApiResponse, Protocol } from '../src/types';
+
+const URL = process.env.AUTHORIZER_URL || 'http://localhost:8080';
+const CLIENT_ID = process.env.CLIENT_ID || 'test-client';
+const ADMIN_SECRET = process.env.ADMIN_SECRET || 'admin';
+const PROTOCOL = (process.env.PROTOCOL || 'graphql') as Protocol; // graphql | rest
+
+const FGA_MODEL = `model
+  schema 1.1
+type user
+type document
+  relations
+    define viewer: [user]`;
+
+// step runs a call, prints data or error, and never throws so the flow runs.
+async function step<T>(label: string, fn: () => Promise<ApiResponse<T>>): Promise<T | undefined> {
+  try {
+    const res = await fn();
+    if (res.errors && res.errors.length) {
+      console.log(`✗ ${label.padEnd(22)} error: ${res.errors.map((e) => e.message).join('; ')}`);
+      return undefined;
+    }
+    console.log(`✓ ${label.padEnd(22)}`, JSON.stringify(res.data));
+    return res.data;
+  } catch (e) {
+    console.log(`✗ ${label.padEnd(22)} error: ${(e as Error).message}`);
+    return undefined;
+  }
+}
+
+async function main() {
+  console.log(`== Authorizer JS SDK manual test ==\nurl=${URL} protocol=${PROTOCOL}\n`);
+
+  const client = new Authorizer({
+    authorizerURL: URL,
+    redirectURL: URL,
+    clientID: CLIENT_ID,
+    protocol: PROTOCOL,
+    // Node (non-browser) must send Origin to pass the server CSRF guard.
+    extraHeaders: { Origin: URL },
+  });
+
+  await step('getMetaData', () => client.getMetaData());
+
+  const email = `js-manual-${Date.now()}@example.com`;
+  await step('signup', () =>
+    client.signup({ email, password: 'Test@12345', confirm_password: 'Test@12345' }),
+  );
+
+  const auth = await step('login', () => client.login({ email, password: 'Test@12345' }));
+
+  if (auth?.access_token) {
+    await step('getProfile', () =>
+      client.getProfile({ Authorization: `Bearer ${auth.access_token}` }),
+    );
+  }
+
+  // ---- Admin client (auth via x-authorizer-admin-secret) ----
+  console.log('\n-- admin --');
+  const admin = new AuthorizerAdmin({
+    authorizerURL: URL,
+    adminSecret: ADMIN_SECRET,
+    protocol: PROTOCOL,
+    extraHeaders: { Origin: URL },
+  });
+
+  const users = await step('users', () => admin.users());
+  if (users) console.log(`   -> ${users.users.length} user(s)`);
+
+  const webhookEndpoint = 'https://example.com/webhook';
+  await step('addWebhook', () =>
+    admin.addWebhook({ event_name: 'user.login', endpoint: webhookEndpoint, enabled: true }),
+  );
+
+  const whs = await step('webhooks', () => admin.webhooks());
+  if (whs) {
+    console.log(`   -> ${whs.webhooks.length} webhook(s)`);
+    // Clean up by endpoint: the server appends a "-<timestamp>" suffix to
+    // event_name (not a stable key); endpoint is stored verbatim.
+    for (const w of whs.webhooks) {
+      if (w.endpoint === webhookEndpoint && w.id) {
+        await step('deleteWebhook', () => admin.deleteWebhook({ id: w.id }));
+      }
+    }
+  }
+
+  // ---- FGA admin ----
+  console.log('\n-- fga admin --');
+  await step('fgaWriteModel', () => admin.fgaWriteModel({ dsl: FGA_MODEL }));
+  const fgaObject = `document:${Date.now()}`; // unique so re-runs don't collide
+  await step('fgaWriteTuples', () =>
+    admin.fgaWriteTuples({ tuples: [{ user: 'user:alice', relation: 'viewer', object: fgaObject }] }),
+  );
+  const tuples = await step('fgaReadTuples', () => admin.fgaReadTuples({}));
+  if (tuples) console.log(`   -> ${tuples.tuples.length} tuple(s)`);
+
+  console.log('\ndone.');
+}
+
+main();

--- a/src/admin.ts
+++ b/src/admin.ts
@@ -1,0 +1,839 @@
+// Note: write gql query in single line to reduce bundle size
+import crossFetch from 'cross-fetch';
+import * as Types from './types';
+import { coerceInt64Fields, hasWindow, trimURL } from './utils';
+
+// set fetch based on window object. Cross fetch have issues with umd build
+const getFetcher = () => (hasWindow() ? window.fetch : crossFetch);
+
+// re-usable gql response fragments shared across admin ops.
+const userFragment =
+  'id email email_verified given_name family_name middle_name nickname preferred_username picture signup_methods gender birthdate phone_number phone_number_verified roles created_at updated_at revoked_timestamp is_multi_factor_auth_enabled app_data';
+const paginationFragment = 'limit page offset total';
+const webhookFragment =
+  'id event_name event_description endpoint enabled headers created_at updated_at';
+const webhookLogFragment =
+  'id http_status response request webhook_id created_at updated_at';
+const emailTemplateFragment =
+  'id event_name template design subject created_at updated_at';
+const auditLogFragment =
+  'id actor_id actor_type actor_email action resource_type resource_id ip_address user_agent metadata created_at';
+
+function toErrorList(errors: unknown): Error[] {
+  if (Array.isArray(errors)) {
+    return errors.map((item) => {
+      if (item instanceof Error) return item;
+      if (item && typeof item === 'object' && 'message' in item)
+        return new Error(String((item as { message: unknown }).message));
+      return new Error(String(item));
+    });
+  }
+  if (errors instanceof Error) return [errors];
+  if (errors !== null && typeof errors === 'object') {
+    const o = errors as Record<string, unknown>;
+    if (typeof o.message === 'string') return [new Error(o.message)];
+    if (typeof o.error === 'string') return [new Error(o.error)];
+  }
+  if (errors === undefined || errors === null)
+    return [new Error('Unknown error')];
+  return [new Error(String(errors))];
+}
+
+// A graphql variant of an admin method: the op string, the named operation and
+// the schema field whose value is the payload to unwrap.
+interface GqlVariant {
+  query: string;
+  operationName: string;
+  op: string;
+}
+
+// A rest variant of an admin method: the mapped admin endpoint plus the
+// proto-gateway wrapper field to unwrap (omitted when the whole body is the
+// payload).
+interface RestVariant {
+  method: 'GET' | 'POST';
+  path: string;
+  unwrap?: string;
+}
+
+/**
+ * Admin client for the Authorizer super-admin API. Constructed with the admin
+ * secret, which is sent on every call via `x-authorizer-admin-secret`; only use
+ * this server-side and never expose the secret to a browser.
+ *
+ * `protocol` selects the wire transport (`'graphql'` default, or `'rest'`).
+ * `'grpc'` is NOT supported in JS and throws. Some methods are available over
+ * only one protocol (e.g. AdminMeta is rest-only, GenerateJWTKeys is
+ * graphql-only); calling such a method over an unsupported protocol throws a
+ * clear error early instead of emitting a 404 / unknown-field.
+ */
+export class AuthorizerAdmin {
+  config: Types.AdminConfigType;
+
+  constructor(config: Types.AdminConfigType) {
+    if (!config) throw new Error('Configuration is required');
+    if (!config.authorizerURL?.trim())
+      throw new Error('Invalid authorizerURL');
+    if (!config.adminSecret?.trim()) throw new Error('Invalid adminSecret');
+
+    if ((config.protocol as string) === 'grpc')
+      throw new Error(
+        'protocol \'grpc\' is not supported in authorizer-js (browsers cannot speak raw gRPC); use \'graphql\' or \'rest\'',
+      );
+
+    this.config = {
+      ...config,
+      authorizerURL: trimURL(config.authorizerURL),
+      protocol: config.protocol || 'graphql',
+    };
+    this.config.extraHeaders = {
+      ...(config.extraHeaders || {}),
+      'x-authorizer-url': this.config.authorizerURL,
+      'x-authorizer-admin-secret': config.adminSecret,
+      'Content-Type': 'application/json',
+    };
+  }
+
+  // ---- transport ----
+
+  // dispatch runs an admin method over the configured protocol. `protocols`
+  // lists which protocols the method supports; calling over an unsupported one
+  // throws early. The payload is unwrapped to the same shape regardless of
+  // protocol so callers get a consistent return type.
+  private dispatch = async <T>(
+    name: string,
+    protocols: Types.Protocol[],
+    gql: GqlVariant | null,
+    rest: RestVariant | null,
+    variables?: Record<string, any>,
+    body?: Record<string, unknown>,
+  ): Promise<Types.ApiResponse<T>> => {
+    const protocol = this.config.protocol as Types.Protocol;
+    if (!protocols.includes(protocol)) {
+      return this.errorResponse([
+        new Error(
+          `${name} is not available over ${protocol}; supported: ${protocols.join(', ')}`,
+        ),
+      ]);
+    }
+    try {
+      if (protocol === 'rest') {
+        const res = await this.restCall(rest!.method, rest!.path, body);
+        if (res.errors.length) return this.errorResponse(res.errors);
+        const data = rest!.unwrap ? res.data?.[rest!.unwrap] : res.data;
+        return this.okResponse(data);
+      }
+      const res = await this.gqlCall(gql!, variables);
+      if (res.errors.length) return this.errorResponse(res.errors);
+      return this.okResponse(res.data?.[gql!.op]);
+    } catch (err) {
+      return this.errorResponse(err);
+    }
+  };
+
+  private gqlCall = async (
+    gql: GqlVariant,
+    variables?: Record<string, any>,
+  ): Promise<{ data?: any; errors: Error[] }> => {
+    const fetcher = getFetcher();
+    const res = await fetcher(`${this.config.authorizerURL}/graphql`, {
+      method: 'POST',
+      body: JSON.stringify({
+        query: gql.query,
+        variables: variables || {},
+        operationName: gql.operationName,
+      }),
+      headers: { ...this.config.extraHeaders },
+      credentials: 'include',
+    });
+
+    const text = await res.text();
+    let json: { data?: any; errors?: unknown[] } = {};
+    if (text) {
+      try {
+        json = JSON.parse(text);
+      } catch {
+        return {
+          data: undefined,
+          errors: [
+            new Error(
+              res.ok
+                ? 'Invalid JSON from GraphQL endpoint'
+                : `HTTP ${res.status}`,
+            ),
+          ],
+        };
+      }
+    } else if (!res.ok) {
+      return { data: undefined, errors: [new Error(`HTTP ${res.status}`)] };
+    }
+    if (json?.errors?.length)
+      return { data: undefined, errors: toErrorList(json.errors) };
+    if (!res.ok)
+      return { data: undefined, errors: [new Error(`HTTP ${res.status}`)] };
+    return { data: json.data, errors: [] };
+  };
+
+  private restCall = async (
+    method: 'GET' | 'POST',
+    path: string,
+    body?: Record<string, unknown>,
+  ): Promise<{ data?: any; errors: Error[] }> => {
+    const fetcher = getFetcher();
+    const res = await fetcher(`${this.config.authorizerURL}${path}`, {
+      method,
+      ...(method === 'POST' ? { body: JSON.stringify(body || {}) } : {}),
+      headers: { ...this.config.extraHeaders },
+      credentials: 'include',
+    });
+
+    const text = await res.text();
+    let json: { error?: string; message?: string } & Record<string, unknown> =
+      {};
+    if (text) {
+      try {
+        json = JSON.parse(text);
+      } catch {
+        return {
+          data: undefined,
+          errors: [
+            new Error(
+              res.ok ? 'Invalid JSON from REST endpoint' : `HTTP ${res.status}`,
+            ),
+          ],
+        };
+      }
+    } else if (!res.ok) {
+      return { data: undefined, errors: [new Error(`HTTP ${res.status}`)] };
+    }
+    if (!res.ok) {
+      return {
+        data: undefined,
+        errors: [
+          new Error(String(json.message || json.error || `HTTP ${res.status}`)),
+        ],
+      };
+    }
+    // proto-gateway serializes int64 fields (pagination limit/page/offset/total,
+    // timestamps, expires) as strings; coerce to numbers so the rest path
+    // returns the same number-typed shape as the graphql path.
+    return { data: coerceInt64Fields(json), errors: [] };
+  };
+
+  private errorResponse = (errors: unknown): Types.ApiResponse<any> => ({
+    data: undefined,
+    errors: toErrorList(errors),
+  });
+
+  private okResponse = (data: any): Types.ApiResponse<any> => ({
+    data,
+    errors: [],
+  });
+
+  // ---- Admin auth + meta ----
+
+  // adminLogin validates the admin secret and establishes an admin session
+  // (Set-Cookie for browser callers).
+  adminLogin = (
+    data: Types.AdminLoginRequest,
+  ): Promise<Types.ApiResponse<Types.Response>> =>
+    this.dispatch<Types.Response>(
+      'AdminLogin',
+      ['graphql', 'rest'],
+      {
+        query:
+          'mutation _admin_login($params: AdminLoginRequest!) { _admin_login(params: $params) { message } }',
+        operationName: '_admin_login',
+        op: '_admin_login',
+      },
+      { method: 'POST', path: '/v1/admin/login' },
+      { params: data },
+      data as unknown as Record<string, unknown>,
+    );
+
+  // adminLogout clears the admin session cookie. (rest-only in JS.)
+  adminLogout = (): Promise<Types.ApiResponse<Types.Response>> =>
+    this.dispatch<Types.Response>(
+      'AdminLogout',
+      ['rest'],
+      null,
+      { method: 'POST', path: '/v1/admin/logout' },
+    );
+
+  // adminSession refreshes the admin session cookie. (rest-only in JS.)
+  adminSession = (): Promise<Types.ApiResponse<Types.Response>> =>
+    this.dispatch<Types.Response>(
+      'AdminSession',
+      ['rest'],
+      null,
+      { method: 'GET', path: '/v1/admin/session' },
+    );
+
+  // adminMeta returns admin-only configuration metadata (configured roles).
+  // (rest-only in JS.)
+  adminMeta = (): Promise<Types.ApiResponse<Types.AdminMeta>> =>
+    this.dispatch<Types.AdminMeta>(
+      'AdminMeta',
+      ['rest'],
+      null,
+      { method: 'GET', path: '/v1/admin/meta', unwrap: 'admin_meta' },
+    );
+
+  // ---- Users ----
+
+  // users returns a paginated list of all users.
+  users = (
+    params?: Types.PaginatedRequest,
+  ): Promise<Types.ApiResponse<Types.Users>> =>
+    this.dispatch<Types.Users>(
+      'Users',
+      ['graphql', 'rest'],
+      {
+        query: `query _users($params: PaginatedRequest) { _users(params: $params) { pagination { ${paginationFragment} } users { ${userFragment} } } }`,
+        operationName: '_users',
+        op: '_users',
+      },
+      { method: 'POST', path: '/v1/admin/users' },
+      { params },
+      (params || {}) as Record<string, unknown>,
+    );
+
+  // user returns a single user by id or email.
+  user = (
+    params: Types.GetUserRequest,
+  ): Promise<Types.ApiResponse<Types.User>> =>
+    this.dispatch<Types.User>(
+      'User',
+      ['graphql', 'rest'],
+      {
+        query: `query _user($params: GetUserRequest!) { _user(params: $params) { ${userFragment} } }`,
+        operationName: '_user',
+        op: '_user',
+      },
+      { method: 'POST', path: '/v1/admin/user', unwrap: 'user' },
+      { params },
+      params as unknown as Record<string, unknown>,
+    );
+
+  // updateUser updates a user's profile, roles, MFA, or verification state.
+  updateUser = (
+    params: Types.UpdateUserRequest,
+  ): Promise<Types.ApiResponse<Types.User>> =>
+    this.dispatch<Types.User>(
+      'UpdateUser',
+      ['graphql', 'rest'],
+      {
+        query: `mutation _update_user($params: UpdateUserRequest!) { _update_user(params: $params) { ${userFragment} } }`,
+        operationName: '_update_user',
+        op: '_update_user',
+      },
+      { method: 'POST', path: '/v1/admin/update_user', unwrap: 'user' },
+      { params },
+      params as unknown as Record<string, unknown>,
+    );
+
+  // deleteUser deletes a user (and associated OTP/verification data) by email.
+  // DESTRUCTIVE: the user and their auth artifacts are permanently removed.
+  deleteUser = (
+    params: Types.DeleteUserRequest,
+  ): Promise<Types.ApiResponse<Types.Response>> =>
+    this.dispatch<Types.Response>(
+      'DeleteUser',
+      ['graphql', 'rest'],
+      {
+        query:
+          'mutation _delete_user($params: DeleteUserRequest!) { _delete_user(params: $params) { message } }',
+        operationName: '_delete_user',
+        op: '_delete_user',
+      },
+      { method: 'POST', path: '/v1/admin/delete_user' },
+      { params },
+      params as unknown as Record<string, unknown>,
+    );
+
+  // verificationRequests returns a paginated list of pending verification requests.
+  verificationRequests = (
+    params?: Types.PaginatedRequest,
+  ): Promise<Types.ApiResponse<Types.VerificationRequests>> =>
+    this.dispatch<Types.VerificationRequests>(
+      'VerificationRequests',
+      ['graphql', 'rest'],
+      {
+        query: `query _verification_requests($params: PaginatedRequest) { _verification_requests(params: $params) { pagination { ${paginationFragment} } verification_requests { id identifier token email expires created_at updated_at nonce redirect_uri } } }`,
+        operationName: '_verification_requests',
+        op: '_verification_requests',
+      },
+      { method: 'POST', path: '/v1/admin/verification_requests' },
+      { params },
+      (params || {}) as Record<string, unknown>,
+    );
+
+  // ---- Access ----
+
+  // revokeAccess revokes a user's access, kills their sessions, and fires the
+  // access-revoked webhook.
+  revokeAccess = (
+    params: Types.UpdateAccessRequest,
+  ): Promise<Types.ApiResponse<Types.Response>> =>
+    this.dispatch<Types.Response>(
+      'RevokeAccess',
+      ['graphql', 'rest'],
+      {
+        query:
+          'mutation _revoke_access($param: UpdateAccessRequest!) { _revoke_access(param: $param) { message } }',
+        operationName: '_revoke_access',
+        op: '_revoke_access',
+      },
+      { method: 'POST', path: '/v1/admin/revoke_access' },
+      { param: params },
+      params as unknown as Record<string, unknown>,
+    );
+
+  // enableAccess re-enables a previously revoked user and fires the
+  // access-enabled webhook.
+  enableAccess = (
+    params: Types.UpdateAccessRequest,
+  ): Promise<Types.ApiResponse<Types.Response>> =>
+    this.dispatch<Types.Response>(
+      'EnableAccess',
+      ['graphql', 'rest'],
+      {
+        query:
+          'mutation _enable_access($param: UpdateAccessRequest!) { _enable_access(param: $param) { message } }',
+        operationName: '_enable_access',
+        op: '_enable_access',
+      },
+      { method: 'POST', path: '/v1/admin/enable_access' },
+      { param: params },
+      params as unknown as Record<string, unknown>,
+    );
+
+  // inviteMembers creates accounts for new emails and sends invite emails
+  // (requires a configured email service).
+  inviteMembers = (
+    params: Types.InviteMemberRequest,
+  ): Promise<Types.ApiResponse<Types.InviteMembersResponse>> =>
+    this.dispatch<Types.InviteMembersResponse>(
+      'InviteMembers',
+      ['graphql', 'rest'],
+      {
+        query: `mutation _invite_members($params: InviteMemberRequest!) { _invite_members(params: $params) { message Users { ${userFragment} } } }`,
+        operationName: '_invite_members',
+        op: '_invite_members',
+      },
+      { method: 'POST', path: '/v1/admin/invite_members' },
+      { params },
+      params as unknown as Record<string, unknown>,
+    );
+
+  // ---- Webhooks ----
+
+  // addWebhook registers a new webhook for an event.
+  addWebhook = (
+    params: Types.AddWebhookRequest,
+  ): Promise<Types.ApiResponse<Types.Response>> =>
+    this.dispatch<Types.Response>(
+      'AddWebhook',
+      ['graphql', 'rest'],
+      {
+        query:
+          'mutation _add_webhook($params: AddWebhookRequest!) { _add_webhook(params: $params) { message } }',
+        operationName: '_add_webhook',
+        op: '_add_webhook',
+      },
+      { method: 'POST', path: '/v1/admin/add_webhook' },
+      { params },
+      params as unknown as Record<string, unknown>,
+    );
+
+  // updateWebhook updates an existing webhook.
+  updateWebhook = (
+    params: Types.UpdateWebhookRequest,
+  ): Promise<Types.ApiResponse<Types.Response>> =>
+    this.dispatch<Types.Response>(
+      'UpdateWebhook',
+      ['graphql', 'rest'],
+      {
+        query:
+          'mutation _update_webhook($params: UpdateWebhookRequest!) { _update_webhook(params: $params) { message } }',
+        operationName: '_update_webhook',
+        op: '_update_webhook',
+      },
+      { method: 'POST', path: '/v1/admin/update_webhook' },
+      { params },
+      params as unknown as Record<string, unknown>,
+    );
+
+  // deleteWebhook deletes a webhook by id. DESTRUCTIVE: the webhook config is
+  // permanently removed.
+  deleteWebhook = (
+    params: Types.WebhookRequest,
+  ): Promise<Types.ApiResponse<Types.Response>> =>
+    this.dispatch<Types.Response>(
+      'DeleteWebhook',
+      ['graphql', 'rest'],
+      {
+        query:
+          'mutation _delete_webhook($params: WebhookRequest!) { _delete_webhook(params: $params) { message } }',
+        operationName: '_delete_webhook',
+        op: '_delete_webhook',
+      },
+      { method: 'POST', path: '/v1/admin/delete_webhook' },
+      { params },
+      params as unknown as Record<string, unknown>,
+    );
+
+  // getWebhook returns a single webhook by id.
+  getWebhook = (
+    params: Types.WebhookRequest,
+  ): Promise<Types.ApiResponse<Types.Webhook>> =>
+    this.dispatch<Types.Webhook>(
+      'GetWebhook',
+      ['graphql', 'rest'],
+      {
+        query: `query _webhook($params: WebhookRequest!) { _webhook(params: $params) { ${webhookFragment} } }`,
+        operationName: '_webhook',
+        op: '_webhook',
+      },
+      { method: 'POST', path: '/v1/admin/webhook', unwrap: 'webhook' },
+      { params },
+      params as unknown as Record<string, unknown>,
+    );
+
+  // webhooks returns a paginated list of webhooks.
+  webhooks = (
+    params?: Types.PaginatedRequest,
+  ): Promise<Types.ApiResponse<Types.Webhooks>> =>
+    this.dispatch<Types.Webhooks>(
+      'Webhooks',
+      ['graphql', 'rest'],
+      {
+        query: `query _webhooks($params: PaginatedRequest) { _webhooks(params: $params) { pagination { ${paginationFragment} } webhooks { ${webhookFragment} } } }`,
+        operationName: '_webhooks',
+        op: '_webhooks',
+      },
+      { method: 'POST', path: '/v1/admin/webhooks' },
+      { params },
+      (params || {}) as Record<string, unknown>,
+    );
+
+  // webhookLogs returns a paginated list of webhook delivery logs, optionally
+  // filtered by webhook id.
+  webhookLogs = (
+    params?: Types.ListWebhookLogRequest,
+  ): Promise<Types.ApiResponse<Types.WebhookLogs>> =>
+    this.dispatch<Types.WebhookLogs>(
+      'WebhookLogs',
+      ['graphql', 'rest'],
+      {
+        query: `query _webhook_logs($params: ListWebhookLogRequest) { _webhook_logs(params: $params) { pagination { ${paginationFragment} } webhook_logs { ${webhookLogFragment} } } }`,
+        operationName: '_webhook_logs',
+        op: '_webhook_logs',
+      },
+      { method: 'POST', path: '/v1/admin/webhook_logs' },
+      { params },
+      (params || {}) as Record<string, unknown>,
+    );
+
+  // testEndpoint sends a synthetic event payload to a webhook endpoint and
+  // returns the HTTP status and response body.
+  testEndpoint = (
+    params: Types.TestEndpointRequest,
+  ): Promise<Types.ApiResponse<Types.TestEndpointResponse>> =>
+    this.dispatch<Types.TestEndpointResponse>(
+      'TestEndpoint',
+      ['graphql', 'rest'],
+      {
+        query:
+          'mutation _test_endpoint($params: TestEndpointRequest!) { _test_endpoint(params: $params) { http_status response } }',
+        operationName: '_test_endpoint',
+        op: '_test_endpoint',
+      },
+      { method: 'POST', path: '/v1/admin/test_endpoint' },
+      { params },
+      params as unknown as Record<string, unknown>,
+    );
+
+  // ---- Email templates ----
+
+  // addEmailTemplate creates a new email template for an event.
+  addEmailTemplate = (
+    params: Types.AddEmailTemplateRequest,
+  ): Promise<Types.ApiResponse<Types.Response>> =>
+    this.dispatch<Types.Response>(
+      'AddEmailTemplate',
+      ['graphql', 'rest'],
+      {
+        query:
+          'mutation _add_email_template($params: AddEmailTemplateRequest!) { _add_email_template(params: $params) { message } }',
+        operationName: '_add_email_template',
+        op: '_add_email_template',
+      },
+      { method: 'POST', path: '/v1/admin/add_email_template' },
+      { params },
+      params as unknown as Record<string, unknown>,
+    );
+
+  // updateEmailTemplate updates an existing email template.
+  updateEmailTemplate = (
+    params: Types.UpdateEmailTemplateRequest,
+  ): Promise<Types.ApiResponse<Types.Response>> =>
+    this.dispatch<Types.Response>(
+      'UpdateEmailTemplate',
+      ['graphql', 'rest'],
+      {
+        query:
+          'mutation _update_email_template($params: UpdateEmailTemplateRequest!) { _update_email_template(params: $params) { message } }',
+        operationName: '_update_email_template',
+        op: '_update_email_template',
+      },
+      { method: 'POST', path: '/v1/admin/update_email_template' },
+      { params },
+      params as unknown as Record<string, unknown>,
+    );
+
+  // deleteEmailTemplate deletes an email template by id. DESTRUCTIVE: the
+  // template is permanently removed.
+  deleteEmailTemplate = (
+    params: Types.DeleteEmailTemplateRequest,
+  ): Promise<Types.ApiResponse<Types.Response>> =>
+    this.dispatch<Types.Response>(
+      'DeleteEmailTemplate',
+      ['graphql', 'rest'],
+      {
+        query:
+          'mutation _delete_email_template($params: DeleteEmailTemplateRequest!) { _delete_email_template(params: $params) { message } }',
+        operationName: '_delete_email_template',
+        op: '_delete_email_template',
+      },
+      { method: 'POST', path: '/v1/admin/delete_email_template' },
+      { params },
+      params as unknown as Record<string, unknown>,
+    );
+
+  // emailTemplates returns a paginated list of email templates.
+  emailTemplates = (
+    params?: Types.PaginatedRequest,
+  ): Promise<Types.ApiResponse<Types.EmailTemplates>> =>
+    this.dispatch<Types.EmailTemplates>(
+      'EmailTemplates',
+      ['graphql', 'rest'],
+      {
+        query: `query _email_templates($params: PaginatedRequest) { _email_templates(params: $params) { pagination { ${paginationFragment} } email_templates { ${emailTemplateFragment} } } }`,
+        operationName: '_email_templates',
+        op: '_email_templates',
+      },
+      { method: 'POST', path: '/v1/admin/email_templates' },
+      { params },
+      (params || {}) as Record<string, unknown>,
+    );
+
+  // ---- Audit ----
+
+  // auditLogs returns a paginated, optionally-filtered list of audit log entries.
+  auditLogs = (
+    params?: Types.ListAuditLogRequest,
+  ): Promise<Types.ApiResponse<Types.AuditLogs>> =>
+    this.dispatch<Types.AuditLogs>(
+      'AuditLogs',
+      ['graphql', 'rest'],
+      {
+        query: `query _audit_logs($params: ListAuditLogRequest) { _audit_logs(params: $params) { pagination { ${paginationFragment} } audit_logs { ${auditLogFragment} } } }`,
+        operationName: '_audit_logs',
+        op: '_audit_logs',
+      },
+      { method: 'POST', path: '/v1/admin/audit_logs' },
+      { params },
+      (params || {}) as Record<string, unknown>,
+    );
+
+  // ---- FGA (fine-grained authorization) admin ----
+
+  // fgaGetModel returns the active fine-grained authorization model as DSL.
+  // (rest-only in JS.)
+  fgaGetModel = (): Promise<Types.ApiResponse<Types.FgaModel>> =>
+    this.dispatch<Types.FgaModel>(
+      'FgaGetModel',
+      ['rest'],
+      null,
+      { method: 'GET', path: '/v1/admin/fga/model', unwrap: 'model' },
+    );
+
+  // fgaWriteModel installs a new fine-grained authorization model from its DSL.
+  // DESTRUCTIVE: replaces the active authorization model.
+  fgaWriteModel = (
+    params: Types.FgaWriteModelInput,
+  ): Promise<Types.ApiResponse<Types.FgaModel>> =>
+    this.dispatch<Types.FgaModel>(
+      'FgaWriteModel',
+      ['graphql', 'rest'],
+      {
+        query:
+          'mutation _fga_write_model($params: FgaWriteModelInput!) { _fga_write_model(params: $params) { id dsl } }',
+        operationName: '_fga_write_model',
+        op: '_fga_write_model',
+      },
+      { method: 'POST', path: '/v1/admin/fga/model', unwrap: 'model' },
+      { params },
+      params as unknown as Record<string, unknown>,
+    );
+
+  // fgaWriteTuples persists the given relationship tuples (additive).
+  fgaWriteTuples = (
+    params: Types.FgaWriteTuplesInput,
+  ): Promise<Types.ApiResponse<Types.Response>> =>
+    this.dispatch<Types.Response>(
+      'FgaWriteTuples',
+      ['graphql', 'rest'],
+      {
+        query:
+          'mutation _fga_write_tuples($params: FgaWriteTuplesInput!) { _fga_write_tuples(params: $params) { message } }',
+        operationName: '_fga_write_tuples',
+        op: '_fga_write_tuples',
+      },
+      { method: 'POST', path: '/v1/admin/fga/tuples' },
+      { params },
+      params as unknown as Record<string, unknown>,
+    );
+
+  // fgaDeleteTuples removes the given relationship tuples. DESTRUCTIVE: the
+  // listed tuples are permanently removed.
+  fgaDeleteTuples = (
+    params: Types.FgaWriteTuplesInput,
+  ): Promise<Types.ApiResponse<Types.Response>> =>
+    this.dispatch<Types.Response>(
+      'FgaDeleteTuples',
+      ['graphql', 'rest'],
+      {
+        query:
+          'mutation _fga_delete_tuples($params: FgaWriteTuplesInput!) { _fga_delete_tuples(params: $params) { message } }',
+        operationName: '_fga_delete_tuples',
+        op: '_fga_delete_tuples',
+      },
+      { method: 'POST', path: '/v1/admin/fga/tuples/delete' },
+      { params },
+      params as unknown as Record<string, unknown>,
+    );
+
+  // fgaReadTuples returns a page of persisted tuples matching the filter.
+  fgaReadTuples = (
+    params: Types.FgaReadTuplesInput,
+  ): Promise<Types.ApiResponse<Types.FgaTuples>> =>
+    this.dispatch<Types.FgaTuples>(
+      'FgaReadTuples',
+      ['graphql', 'rest'],
+      {
+        query:
+          'query _fga_read_tuples($params: FgaReadTuplesInput!) { _fga_read_tuples(params: $params) { tuples { user relation object } continuation_token } }',
+        operationName: '_fga_read_tuples',
+        op: '_fga_read_tuples',
+      },
+      { method: 'POST', path: '/v1/admin/fga/tuples/read' },
+      { params },
+      params as unknown as Record<string, unknown>,
+    );
+
+  // fgaListUsers returns the fully-qualified user ids of user_type that have
+  // relation on object ("who can access this object?").
+  fgaListUsers = (
+    params: Types.FgaListUsersInput,
+  ): Promise<Types.ApiResponse<Types.FgaListUsersResponse>> =>
+    this.dispatch<Types.FgaListUsersResponse>(
+      'FgaListUsers',
+      ['graphql', 'rest'],
+      {
+        query:
+          'query _fga_list_users($params: FgaListUsersInput!) { _fga_list_users(params: $params) { users } }',
+        operationName: '_fga_list_users',
+        op: '_fga_list_users',
+      },
+      { method: 'POST', path: '/v1/admin/fga/list_users' },
+      { params },
+      params as unknown as Record<string, unknown>,
+    );
+
+  // fgaExpand returns the OpenFGA relationship/userset tree for (relation,
+  // object) as a JSON string.
+  fgaExpand = (
+    params: Types.FgaExpandInput,
+  ): Promise<Types.ApiResponse<Types.FgaExpandResponse>> =>
+    this.dispatch<Types.FgaExpandResponse>(
+      'FgaExpand',
+      ['graphql', 'rest'],
+      {
+        query:
+          'query _fga_expand($params: FgaExpandInput!) { _fga_expand(params: $params) { tree } }',
+        operationName: '_fga_expand',
+        op: '_fga_expand',
+      },
+      { method: 'POST', path: '/v1/admin/fga/expand' },
+      { params },
+      params as unknown as Record<string, unknown>,
+    );
+
+  // fgaReset deletes the entire fine-grained authorization store (the model,
+  // all its versions, and all tuples) and starts a fresh, empty store. Refused
+  // while any tuples still exist. DESTRUCTIVE. (rest-only in JS.)
+  fgaReset = (): Promise<Types.ApiResponse<Types.Response>> =>
+    this.dispatch<Types.Response>(
+      'FgaReset',
+      ['rest'],
+      null,
+      { method: 'POST', path: '/v1/admin/fga/reset' },
+    );
+
+  // ---- gql-only extras (no proto / no rest) ----
+
+  // adminSignup sets the admin secret on a fresh deployment. (graphql-only.)
+  adminSignup = (
+    params: Types.AdminSignupRequest,
+  ): Promise<Types.ApiResponse<Types.Response>> =>
+    this.dispatch<Types.Response>(
+      'AdminSignup',
+      ['graphql'],
+      {
+        query:
+          'mutation _admin_signup($params: AdminSignupRequest!) { _admin_signup(params: $params) { message } }',
+        operationName: '_admin_signup',
+        op: '_admin_signup',
+      },
+      null,
+      { params },
+    );
+
+  // updateEnv updates server environment configuration. (graphql-only.)
+  // `params` mirrors the GraphQL UpdateEnvRequest input (free-form config keys).
+  updateEnv = (
+    params: Record<string, any>,
+  ): Promise<Types.ApiResponse<Types.Response>> =>
+    this.dispatch<Types.Response>(
+      'UpdateEnv',
+      ['graphql'],
+      {
+        query:
+          'mutation _update_env($params: UpdateEnvRequest!) { _update_env(params: $params) { message } }',
+        operationName: '_update_env',
+        op: '_update_env',
+      },
+      null,
+      { params },
+    );
+
+  // generateJWTKeys generates a fresh secret / key pair of the given type.
+  // (graphql-only.)
+  generateJWTKeys = (
+    params: Types.GenerateJWTKeysRequest,
+  ): Promise<Types.ApiResponse<Types.GenerateJWTKeysResponse>> =>
+    this.dispatch<Types.GenerateJWTKeysResponse>(
+      'GenerateJWTKeys',
+      ['graphql'],
+      {
+        query:
+          'query _generate_jwt_keys($params: GenerateJWTKeysRequest!) { _generate_jwt_keys(params: $params) { secret public_key private_key } }',
+        operationName: '_generate_jwt_keys',
+        op: '_generate_jwt_keys',
+      },
+      null,
+      { params },
+    );
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import { DEFAULT_AUTHORIZE_TIMEOUT_IN_SECONDS } from './constants';
 import * as Types from './types';
 import {
   bufferToBase64UrlEncoded,
+  coerceInt64Fields,
   createQueryParams,
   createRandomString,
   encode,
@@ -50,6 +51,7 @@ function toErrorList(errors: unknown): Error[] {
 }
 
 export * from './types';
+export { AuthorizerAdmin } from './admin';
 
 /**
  * Client for the Authorizer API. All network calls go to `config.authorizerURL`
@@ -72,6 +74,12 @@ export class Authorizer {
     if (!config.redirectURL?.trim()) throw new Error('Invalid redirectURL');
     this.config.redirectURL = trimURL(config.redirectURL);
     this.config.clientID = (config?.clientID || '').trim();
+
+    if ((config.protocol as string) === 'grpc')
+      throw new Error(
+        'protocol \'grpc\' is not supported in authorizer-js (browsers cannot speak raw gRPC); use \'graphql\' or \'rest\'',
+      );
+    this.config.protocol = config.protocol || 'graphql';
 
     this.config.extraHeaders = {
       ...(config.extraHeaders || {}),
@@ -195,17 +203,21 @@ export class Authorizer {
     if (!data.redirect_uri) data.redirect_uri = this.config.redirectURL;
 
     try {
-      const forgotPasswordResp = await this.graphqlQuery({
-        query:
-          'mutation forgot_password($data: ForgotPasswordRequest!) {	forgot_password(params: $data) { message should_show_mobile_otp_screen } }',
-        variables: {
-          data,
+      const forgotPasswordResp = await this.dispatch(
+        'forgotPassword',
+        ['graphql', 'rest'],
+        {
+          query:
+            'mutation forgot_password($data: ForgotPasswordRequest!) {	forgot_password(params: $data) { message should_show_mobile_otp_screen } }',
+          operationName: 'forgot_password',
+          op: 'forgot_password',
         },
-        operationName: 'forgot_password',
-      });
+        { method: 'POST', path: '/v1/forgot_password', body: data },
+        { data },
+      );
       return forgotPasswordResp?.errors?.length
         ? this.errorResponse(forgotPasswordResp.errors)
-        : this.okResponse(forgotPasswordResp?.data?.forgot_password);
+        : this.okResponse(forgotPasswordResp?.data);
     } catch (error) {
       return this.errorResponse([error]);
     }
@@ -213,15 +225,21 @@ export class Authorizer {
 
   getMetaData = async (): Promise<Types.ApiResponse<Types.MetaData>> => {
     try {
-      const res = await this.graphqlQuery({
-        query:
-          'query meta { meta { version client_id is_google_login_enabled is_facebook_login_enabled is_github_login_enabled is_linkedin_login_enabled is_apple_login_enabled is_twitter_login_enabled is_microsoft_login_enabled is_twitch_login_enabled is_roblox_login_enabled is_email_verification_enabled is_basic_authentication_enabled is_magic_link_login_enabled is_sign_up_enabled is_strong_password_enabled is_multi_factor_auth_enabled is_mobile_basic_authentication_enabled is_phone_verification_enabled } }',
-        operationName: 'meta',
-      });
+      const res = await this.dispatch(
+        'getMetaData',
+        ['graphql', 'rest'],
+        {
+          query:
+            'query meta { meta { version client_id is_google_login_enabled is_facebook_login_enabled is_github_login_enabled is_linkedin_login_enabled is_apple_login_enabled is_discord_login_enabled is_twitter_login_enabled is_microsoft_login_enabled is_twitch_login_enabled is_roblox_login_enabled is_email_verification_enabled is_basic_authentication_enabled is_magic_link_login_enabled is_sign_up_enabled is_strong_password_enabled is_multi_factor_auth_enabled is_mobile_basic_authentication_enabled is_phone_verification_enabled } }',
+          operationName: 'meta',
+          op: 'meta',
+        },
+        { method: 'GET', path: '/v1/meta' },
+      );
 
       return res?.errors?.length
         ? this.errorResponse(res.errors)
-        : this.okResponse(res.data.meta);
+        : this.okResponse(res.data);
     } catch (error) {
       return this.errorResponse([error]);
     }
@@ -231,15 +249,22 @@ export class Authorizer {
     headers?: Types.Headers,
   ): Promise<Types.ApiResponse<Types.User>> => {
     try {
-      const profileRes = await this.graphqlQuery({
-        query: `query profile {	profile { ${userFragment} } }`,
+      const profileRes = await this.dispatch(
+        'getProfile',
+        ['graphql', 'rest'],
+        {
+          query: `query profile {	profile { ${userFragment} } }`,
+          operationName: 'profile',
+          op: 'profile',
+        },
+        { method: 'GET', path: '/v1/profile' },
+        undefined,
         headers,
-        operationName: 'profile',
-      });
+      );
 
       return profileRes?.errors?.length
         ? this.errorResponse(profileRes.errors)
-        : this.okResponse(profileRes.data.profile);
+        : this.okResponse(profileRes.data);
     } catch (error) {
       return this.errorResponse([error]);
     }
@@ -260,17 +285,23 @@ export class Authorizer {
     headers?: Types.Headers,
   ): Promise<Types.ApiResponse<Types.CheckPermissionsResponse>> => {
     try {
-      const res = await this.graphqlQuery({
-        query:
-          'query checkPermissions($params: CheckPermissionsInput!){ check_permissions(params: $params) { results { relation object allowed } } }',
+      const res = await this.dispatch(
+        'checkPermissions',
+        ['graphql', 'rest'],
+        {
+          query:
+            'query checkPermissions($params: CheckPermissionsInput!){ check_permissions(params: $params) { results { relation object allowed } } }',
+          operationName: 'checkPermissions',
+          op: 'check_permissions',
+        },
+        { method: 'POST', path: '/v1/check_permissions', body: params },
+        { params },
         headers,
-        variables: { params },
-        operationName: 'checkPermissions',
-      });
+      );
 
       return res?.errors?.length
         ? this.errorResponse(res.errors)
-        : this.okResponse(res.data?.check_permissions);
+        : this.okResponse(res.data);
     } catch (error) {
       return this.errorResponse([error]);
     }
@@ -287,17 +318,23 @@ export class Authorizer {
     headers?: Types.Headers,
   ): Promise<Types.ApiResponse<Types.ListPermissionsResponse>> => {
     try {
-      const res = await this.graphqlQuery({
-        query:
-          'query listPermissions($params: ListPermissionsInput!){ list_permissions(params: $params) { objects } }',
+      const res = await this.dispatch(
+        'listPermissions',
+        ['graphql', 'rest'],
+        {
+          query:
+            'query listPermissions($params: ListPermissionsInput!){ list_permissions(params: $params) { objects } }',
+          operationName: 'listPermissions',
+          op: 'list_permissions',
+        },
+        { method: 'POST', path: '/v1/list_permissions', body: params },
+        { params },
         headers,
-        variables: { params },
-        operationName: 'listPermissions',
-      });
+      );
 
       return res?.errors?.length
         ? this.errorResponse(res.errors)
-        : this.okResponse(res.data?.list_permissions);
+        : this.okResponse(res.data);
     } catch (error) {
       return this.errorResponse([error]);
     }
@@ -309,17 +346,25 @@ export class Authorizer {
     params?: Types.SessionQueryRequest,
   ): Promise<Types.ApiResponse<Types.AuthToken>> => {
     try {
-      const res = await this.graphqlQuery({
-        query: `query session($params: SessionQueryRequest){session(params: $params) { ${authTokenFragment} } }`,
-        headers,
-        variables: {
-          params,
+      const res = await this.dispatch(
+        'getSession',
+        ['graphql', 'rest'],
+        {
+          query: `query session($params: SessionQueryRequest){session(params: $params) { ${authTokenFragment} } }`,
+          operationName: 'session',
+          op: 'session',
         },
-        operationName: 'session',
-      });
+        {
+          method: 'POST',
+          path: '/v1/session',
+          body: params || {},
+        },
+        { params },
+        headers,
+      );
       return res?.errors?.length
         ? this.errorResponse(res.errors)
-        : this.okResponse(res.data?.session);
+        : this.okResponse(res.data);
     } catch (err) {
       return this.errorResponse(err);
     }
@@ -393,17 +438,21 @@ export class Authorizer {
     data: Types.LoginRequest,
   ): Promise<Types.ApiResponse<Types.AuthToken>> => {
     try {
-      const res = await this.graphqlQuery({
-        query: `
-					mutation login($data: LoginRequest!) { login(params: $data) { ${authTokenFragment}}}
-				`,
-        variables: { data },
-        operationName: 'login',
-      });
+      const res = await this.dispatch(
+        'login',
+        ['graphql', 'rest'],
+        {
+          query: `mutation login($data: LoginRequest!) { login(params: $data) { ${authTokenFragment}}}`,
+          operationName: 'login',
+          op: 'login',
+        },
+        { method: 'POST', path: '/v1/login', body: data },
+        { data },
+      );
 
       return res?.errors?.length
         ? this.errorResponse(res.errors)
-        : this.okResponse(res.data?.login);
+        : this.okResponse(res.data);
     } catch (err) {
       return this.errorResponse(err);
     }
@@ -413,14 +462,21 @@ export class Authorizer {
     headers?: Types.Headers,
   ): Promise<Types.ApiResponse<Types.GenericResponse>> => {
     try {
-      const res = await this.graphqlQuery({
-        query: 'mutation logout { logout { message } }',
+      const res = await this.dispatch(
+        'logout',
+        ['graphql', 'rest'],
+        {
+          query: 'mutation logout { logout { message } }',
+          operationName: 'logout',
+          op: 'logout',
+        },
+        { method: 'POST', path: '/v1/logout' },
+        undefined,
         headers,
-        operationName: 'logout',
-      });
+      );
       return res?.errors?.length
         ? this.errorResponse(res.errors)
-        : this.okResponse(res.data?.logout);
+        : this.okResponse(res.data);
     } catch (err) {
       return this.errorResponse([err]);
     }
@@ -434,17 +490,21 @@ export class Authorizer {
 
       if (!data.redirect_uri) data.redirect_uri = this.config.redirectURL;
 
-      const res = await this.graphqlQuery({
-        query: `
-					mutation magic_link_login($data: MagicLinkLoginRequest!) { magic_link_login(params: $data) { message }}
-				`,
-        variables: { data },
-        operationName: 'magic_link_login',
-      });
+      const res = await this.dispatch(
+        'magicLinkLogin',
+        ['graphql', 'rest'],
+        {
+          query: 'mutation magic_link_login($data: MagicLinkLoginRequest!) { magic_link_login(params: $data) { message }}',
+          operationName: 'magic_link_login',
+          op: 'magic_link_login',
+        },
+        { method: 'POST', path: '/v1/magic_link_login', body: data },
+        { data },
+      );
 
       return res?.errors?.length
         ? this.errorResponse(res.errors)
-        : this.okResponse(res.data?.magic_link_login);
+        : this.okResponse(res.data);
     } catch (err) {
       return this.errorResponse([err]);
     }
@@ -483,17 +543,21 @@ export class Authorizer {
     data: Types.ResendOtpRequest,
   ): Promise<Types.ApiResponse<Types.GenericResponse>> => {
     try {
-      const res = await this.graphqlQuery({
-        query: `
-					mutation resend_otp($data: ResendOTPRequest!) { resend_otp(params: $data) { message }}
-				`,
-        variables: { data },
-        operationName: 'resend_otp',
-      });
+      const res = await this.dispatch(
+        'resendOtp',
+        ['graphql', 'rest'],
+        {
+          query: 'mutation resend_otp($data: ResendOTPRequest!) { resend_otp(params: $data) { message }}',
+          operationName: 'resend_otp',
+          op: 'resend_otp',
+        },
+        { method: 'POST', path: '/v1/resend_otp', body: data },
+        { data },
+      );
 
       return res?.errors?.length
         ? this.errorResponse(res.errors)
-        : this.okResponse(res.data?.resend_otp);
+        : this.okResponse(res.data);
     } catch (err) {
       return this.errorResponse([err]);
     }
@@ -503,17 +567,21 @@ export class Authorizer {
     data: Types.ResetPasswordRequest,
   ): Promise<Types.ApiResponse<Types.GenericResponse>> => {
     try {
-      const resetPasswordRes = await this.graphqlQuery({
-        query:
-          'mutation reset_password($data: ResetPasswordRequest!) {	reset_password(params: $data) { message } }',
-        variables: {
-          data,
+      const resetPasswordRes = await this.dispatch(
+        'resetPassword',
+        ['graphql', 'rest'],
+        {
+          query:
+            'mutation reset_password($data: ResetPasswordRequest!) {	reset_password(params: $data) { message } }',
+          operationName: 'reset_password',
+          op: 'reset_password',
         },
-        operationName: 'reset_password',
-      });
+        { method: 'POST', path: '/v1/reset_password', body: data },
+        { data },
+      );
       return resetPasswordRes?.errors?.length
         ? this.errorResponse(resetPasswordRes.errors)
-        : this.okResponse(resetPasswordRes.data?.reset_password);
+        : this.okResponse(resetPasswordRes.data);
     } catch (error) {
       return this.errorResponse([error]);
     }
@@ -578,17 +646,21 @@ export class Authorizer {
     data: Types.SignUpRequest,
   ): Promise<Types.ApiResponse<Types.AuthToken>> => {
     try {
-      const res = await this.graphqlQuery({
-        query: `
-					mutation signup($data: SignUpRequest!) { signup(params: $data) { ${authTokenFragment}}}
-				`,
-        variables: { data },
-        operationName: 'signup',
-      });
+      const res = await this.dispatch(
+        'signup',
+        ['graphql', 'rest'],
+        {
+          query: `mutation signup($data: SignUpRequest!) { signup(params: $data) { ${authTokenFragment}}}`,
+          operationName: 'signup',
+          op: 'signup',
+        },
+        { method: 'POST', path: '/v1/signup', body: data },
+        { data },
+      );
 
       return res?.errors?.length
         ? this.errorResponse(res.errors)
-        : this.okResponse(res.data?.signup);
+        : this.okResponse(res.data);
     } catch (err) {
       return this.errorResponse([err]);
     }
@@ -599,19 +671,23 @@ export class Authorizer {
     headers?: Types.Headers,
   ): Promise<Types.ApiResponse<Types.GenericResponse>> => {
     try {
-      const updateProfileRes = await this.graphqlQuery({
-        query:
-          'mutation update_profile($data: UpdateProfileRequest!) {	update_profile(params: $data) { message } }',
-        headers,
-        variables: {
-          data,
+      const updateProfileRes = await this.dispatch(
+        'updateProfile',
+        ['graphql', 'rest'],
+        {
+          query:
+            'mutation update_profile($data: UpdateProfileRequest!) {	update_profile(params: $data) { message } }',
+          operationName: 'update_profile',
+          op: 'update_profile',
         },
-        operationName: 'update_profile',
-      });
+        { method: 'POST', path: '/v1/update_profile', body: data },
+        { data },
+        headers,
+      );
 
       return updateProfileRes?.errors?.length
         ? this.errorResponse(updateProfileRes.errors)
-        : this.okResponse(updateProfileRes.data?.update_profile);
+        : this.okResponse(updateProfileRes.data);
     } catch (error) {
       return this.errorResponse([error]);
     }
@@ -621,14 +697,22 @@ export class Authorizer {
     headers?: Types.Headers,
   ): Promise<Types.ApiResponse<Types.GenericResponse>> => {
     try {
-      const res = await this.graphqlQuery({
-        query: 'mutation deactivate_account { deactivate_account { message } }',
+      const res = await this.dispatch(
+        'deactivateAccount',
+        ['graphql', 'rest'],
+        {
+          query:
+            'mutation deactivate_account { deactivate_account { message } }',
+          operationName: 'deactivate_account',
+          op: 'deactivate_account',
+        },
+        { method: 'POST', path: '/v1/deactivate_account' },
+        undefined,
         headers,
-        operationName: 'deactivate_account',
-      });
+      );
       return res?.errors?.length
         ? this.errorResponse(res.errors)
-        : this.okResponse(res.data?.deactivate_account);
+        : this.okResponse(res.data);
     } catch (error) {
       return this.errorResponse([error]);
     }
@@ -638,18 +722,22 @@ export class Authorizer {
     params?: Types.ValidateJWTTokenRequest,
   ): Promise<Types.ApiResponse<Types.ValidateJWTTokenResponse>> => {
     try {
-      const res = await this.graphqlQuery({
-        query:
-          'query validate_jwt_token($params: ValidateJWTTokenRequest!){validate_jwt_token(params: $params) { is_valid claims } }',
-        variables: {
-          params,
+      const res = await this.dispatch(
+        'validateJWTToken',
+        ['graphql', 'rest'],
+        {
+          query:
+            'query validate_jwt_token($params: ValidateJWTTokenRequest!){validate_jwt_token(params: $params) { is_valid claims } }',
+          operationName: 'validate_jwt_token',
+          op: 'validate_jwt_token',
         },
-        operationName: 'validate_jwt_token',
-      });
+        { method: 'POST', path: '/v1/validate_jwt_token', body: params },
+        { params },
+      );
 
       return res?.errors?.length
         ? this.errorResponse(res.errors)
-        : this.okResponse(res.data?.validate_jwt_token);
+        : this.okResponse(res.data);
     } catch (error) {
       return this.errorResponse([error]);
     }
@@ -659,17 +747,21 @@ export class Authorizer {
     params?: Types.ValidateSessionRequest,
   ): Promise<Types.ApiResponse<Types.ValidateSessionResponse>> => {
     try {
-      const res = await this.graphqlQuery({
-        query: `query validate_session($params: ValidateSessionRequest){validate_session(params: $params) { is_valid user { ${userFragment} } } }`,
-        variables: {
-          params,
+      const res = await this.dispatch(
+        'validateSession',
+        ['graphql', 'rest'],
+        {
+          query: `query validate_session($params: ValidateSessionRequest){validate_session(params: $params) { is_valid user { ${userFragment} } } }`,
+          operationName: 'validate_session',
+          op: 'validate_session',
         },
-        operationName: 'validate_session',
-      });
+        { method: 'POST', path: '/v1/validate_session', body: params },
+        { params },
+      );
 
       return res?.errors?.length
         ? this.errorResponse(res.errors)
-        : this.okResponse(res.data?.validate_session);
+        : this.okResponse(res.data);
     } catch (error) {
       return this.errorResponse([error]);
     }
@@ -679,17 +771,21 @@ export class Authorizer {
     data: Types.VerifyEmailRequest,
   ): Promise<Types.ApiResponse<Types.AuthToken>> => {
     try {
-      const res = await this.graphqlQuery({
-        query: `
-					mutation verify_email($data: VerifyEmailRequest!) { verify_email(params: $data) { ${authTokenFragment}}}
-				`,
-        variables: { data },
-        operationName: 'verify_email',
-      });
+      const res = await this.dispatch(
+        'verifyEmail',
+        ['graphql', 'rest'],
+        {
+          query: `mutation verify_email($data: VerifyEmailRequest!) { verify_email(params: $data) { ${authTokenFragment}}}`,
+          operationName: 'verify_email',
+          op: 'verify_email',
+        },
+        { method: 'POST', path: '/v1/verify_email', body: data },
+        { data },
+      );
 
       return res?.errors?.length
         ? this.errorResponse(res.errors)
-        : this.okResponse(res.data?.verify_email);
+        : this.okResponse(res.data);
     } catch (err) {
       return this.errorResponse([err]);
     }
@@ -699,17 +795,21 @@ export class Authorizer {
     data: Types.ResendVerifyEmailRequest,
   ): Promise<Types.ApiResponse<Types.GenericResponse>> => {
     try {
-      const res = await this.graphqlQuery({
-        query: `
-					mutation resend_verify_email($data: ResendVerifyEmailRequest!) { resend_verify_email(params: $data) { message }}
-				`,
-        variables: { data },
-        operationName: 'resend_verify_email',
-      });
+      const res = await this.dispatch(
+        'resendVerifyEmail',
+        ['graphql', 'rest'],
+        {
+          query: 'mutation resend_verify_email($data: ResendVerifyEmailRequest!) { resend_verify_email(params: $data) { message }}',
+          operationName: 'resend_verify_email',
+          op: 'resend_verify_email',
+        },
+        { method: 'POST', path: '/v1/resend_verify_email', body: data },
+        { data },
+      );
 
       return res?.errors?.length
         ? this.errorResponse(res.errors)
-        : this.okResponse(res.data?.resend_verify_email);
+        : this.okResponse(res.data);
     } catch (err) {
       return this.errorResponse([err]);
     }
@@ -719,17 +819,21 @@ export class Authorizer {
     data: Types.VerifyOtpRequest,
   ): Promise<Types.ApiResponse<Types.AuthToken>> => {
     try {
-      const res = await this.graphqlQuery({
-        query: `
-					mutation verify_otp($data: VerifyOTPRequest!) { verify_otp(params: $data) { ${authTokenFragment}}}
-				`,
-        variables: { data },
-        operationName: 'verify_otp',
-      });
+      const res = await this.dispatch(
+        'verifyOtp',
+        ['graphql', 'rest'],
+        {
+          query: `mutation verify_otp($data: VerifyOTPRequest!) { verify_otp(params: $data) { ${authTokenFragment}}}`,
+          operationName: 'verify_otp',
+          op: 'verify_otp',
+        },
+        { method: 'POST', path: '/v1/verify_otp', body: data },
+        { data },
+      );
 
       return res?.errors?.length
         ? this.errorResponse(res.errors)
-        : this.okResponse(res.data?.verify_otp);
+        : this.okResponse(res.data);
     } catch (err) {
       return this.errorResponse([err]);
     }
@@ -794,6 +898,114 @@ export class Authorizer {
     }
 
     return { data: json.data, errors: [] };
+  };
+
+  // dispatch runs a public method over the configured protocol and returns the
+  // same flat payload regardless of protocol. As of server 2.3.0-rc.9 (PR #635)
+  // every public RPC works over both graphql and rest and the response envelope
+  // is flat and byte-identical between them (snake_case): graphql reads
+  // `data[gql.op]` (e.g. `data.signup` = AuthResponse), and rest returns the
+  // same bare message as the body — no wrapper unwrapping. `rest.unwrap` remains
+  // for the rare endpoint that still wraps. Each method passes the protocols it
+  // supports; calling over an unsupported one raises a clear error early.
+  dispatch = async (
+    name: string,
+    protocols: Types.Protocol[],
+    gql: { query: string; operationName: string; op: string },
+    rest: {
+      method: 'GET' | 'POST';
+      path: string;
+      body?: Record<string, any>;
+      unwrap?: string;
+    },
+    variables?: Record<string, any>,
+    headers?: Types.Headers,
+  ): Promise<Types.GrapQlResponseType> => {
+    const protocol = this.config.protocol as Types.Protocol;
+    if (!protocols.includes(protocol)) {
+      return {
+        data: undefined,
+        errors: [
+          new Error(
+            `${name} is not available over ${protocol}; supported: ${protocols.join(', ')}`,
+          ),
+        ],
+      };
+    }
+    if (protocol === 'rest') {
+      const res = await this.restQuery(
+        rest.method,
+        rest.path,
+        rest.body,
+        headers,
+      );
+      if (res.errors.length) return res;
+      const data = rest.unwrap ? res.data?.[rest.unwrap] : res.data;
+      return { data, errors: [] };
+    }
+    const res = await this.graphqlQuery({
+      query: gql.query,
+      variables,
+      headers,
+      operationName: gql.operationName,
+    });
+    if (res.errors.length) return res;
+    return { data: res.data?.[gql.op], errors: [] };
+  };
+
+  // helper to execute a public REST call (POST/GET /v1/<snake>). Reuses the
+  // same fetch / credentials / Origin handling as graphqlQuery. Returns the
+  // parsed JSON body (the proto-gateway response shape) under `data`.
+  restQuery = async (
+    method: 'GET' | 'POST',
+    path: string,
+    body?: Record<string, unknown>,
+    headers?: Types.Headers,
+  ): Promise<Types.GrapQlResponseType> => {
+    const fetcher = getFetcher();
+    const res = await fetcher(`${this.config.authorizerURL}${path}`, {
+      method,
+      ...(method === 'POST' ? { body: JSON.stringify(body || {}) } : {}),
+      headers: {
+        ...this.config.extraHeaders,
+        ...(headers || {}),
+      },
+      credentials: 'include',
+    });
+
+    const text = await res.text();
+    let json: { error?: string; message?: string } & Record<string, unknown> =
+      {};
+    if (text) {
+      try {
+        json = JSON.parse(text);
+      } catch {
+        return {
+          data: undefined,
+          errors: [
+            new Error(
+              res.ok ? 'Invalid JSON from REST endpoint' : `HTTP ${res.status}`,
+            ),
+          ],
+        };
+      }
+    } else if (!res.ok) {
+      return { data: undefined, errors: [new Error(`HTTP ${res.status}`)] };
+    }
+
+    if (!res.ok) {
+      // gRPC-gateway errors come back as { code, message, details }.
+      return {
+        data: undefined,
+        errors: [
+          new Error(String(json.message || json.error || `HTTP ${res.status}`)),
+        ],
+      };
+    }
+
+    // proto-gateway serializes int64 fields as strings; coerce to numbers so the
+    // rest path returns the same number-typed shape as the graphql path.
+    return { data: coerceInt64Fields(json), errors: [] };
   };
 
   errorResponse = (errors: unknown): Types.ApiResponse<any> => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -77,7 +77,7 @@ export class Authorizer {
 
     if ((config.protocol as string) === 'grpc')
       throw new Error(
-        'protocol \'grpc\' is not supported in authorizer-js (browsers cannot speak raw gRPC); use \'graphql\' or \'rest\'',
+        "protocol 'grpc' is not supported in authorizer-js (browsers cannot speak raw gRPC); use 'graphql' or 'rest'",
       );
     this.config.protocol = config.protocol || 'graphql';
 
@@ -494,7 +494,8 @@ export class Authorizer {
         'magicLinkLogin',
         ['graphql', 'rest'],
         {
-          query: 'mutation magic_link_login($data: MagicLinkLoginRequest!) { magic_link_login(params: $data) { message }}',
+          query:
+            'mutation magic_link_login($data: MagicLinkLoginRequest!) { magic_link_login(params: $data) { message }}',
           operationName: 'magic_link_login',
           op: 'magic_link_login',
         },
@@ -547,7 +548,8 @@ export class Authorizer {
         'resendOtp',
         ['graphql', 'rest'],
         {
-          query: 'mutation resend_otp($data: ResendOTPRequest!) { resend_otp(params: $data) { message }}',
+          query:
+            'mutation resend_otp($data: ResendOTPRequest!) { resend_otp(params: $data) { message }}',
           operationName: 'resend_otp',
           op: 'resend_otp',
         },
@@ -799,7 +801,8 @@ export class Authorizer {
         'resendVerifyEmail',
         ['graphql', 'rest'],
         {
-          query: 'mutation resend_verify_email($data: ResendVerifyEmailRequest!) { resend_verify_email(params: $data) { message }}',
+          query:
+            'mutation resend_verify_email($data: ResendVerifyEmailRequest!) { resend_verify_email(params: $data) { message }}',
           operationName: 'resend_verify_email',
           op: 'resend_verify_email',
         },
@@ -901,7 +904,7 @@ export class Authorizer {
   };
 
   // dispatch runs a public method over the configured protocol and returns the
-  // same flat payload regardless of protocol. As of server 2.3.0-rc.9 (PR #635)
+  // same flat payload regardless of protocol. As of server 2.3.0 (PR #635)
   // every public RPC works over both graphql and rest and the response envelope
   // is flat and byte-identical between them (snake_case): graphql reads
   // `data[gql.op]` (e.g. `data.signup` = AuthResponse), and rest returns the

--- a/src/index.ts
+++ b/src/index.ts
@@ -77,7 +77,7 @@ export class Authorizer {
 
     if ((config.protocol as string) === 'grpc')
       throw new Error(
-        "protocol 'grpc' is not supported in authorizer-js (browsers cannot speak raw gRPC); use 'graphql' or 'rest'",
+        'protocol \'grpc\' is not supported in authorizer-js (browsers cannot speak raw gRPC); use \'graphql\' or \'rest\'',
       );
     this.config.protocol = config.protocol || 'graphql';
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,7 +17,17 @@ export interface ConfigType {
   redirectURL: string;
   clientID?: string;
   extraHeaders?: Record<string, string>;
+  /**
+   * Wire protocol for the client's public API calls. Defaults to `'graphql'`
+   * (POST /graphql, fully backward compatible). `'rest'` maps each method to
+   * its public `POST/GET /v1/<snake>` endpoint. `'grpc'` is NOT supported in
+   * JS (browsers cannot speak raw gRPC) — passing it throws.
+   */
+  protocol?: Protocol;
 }
+
+// Protocol selects the wire transport. JS supports graphql + rest only.
+export type Protocol = 'graphql' | 'rest';
 
 // Pagination
 export interface Pagination {
@@ -477,3 +487,295 @@ export type MetaDataResponse = Meta;
 
 // Keep MetaData as alias for backward compatibility
 export type MetaData = Meta;
+
+// ============================================================================
+// Admin API types (AuthorizerAdmin).
+//
+// These mirror the AuthorizerAdminService proto / `_`-prefixed GraphQL admin
+// surface. Field names stay snake_case to match the rest of this SDK and the
+// server's GraphQL/REST payloads. Every admin call authenticates with the
+// `x-authorizer-admin-secret` header.
+// ============================================================================
+
+/**
+ * AuthorizerAdmin configuration. Like {@link ConfigType}, requests target
+ * `authorizerURL` (the exact, trusted origin of your Authorizer deployment).
+ * The `adminSecret` is sent on every call via `x-authorizer-admin-secret`, so
+ * only ever construct this in a trusted server-side context — never ship the
+ * admin secret to a browser.
+ */
+export interface AdminConfigType {
+  authorizerURL: string;
+  adminSecret: string;
+  extraHeaders?: Record<string, string>;
+  /** `'graphql'` (default) or `'rest'`. `'grpc'` is not supported in JS. */
+  protocol?: Protocol;
+}
+
+// PaginationRequest is the page/limit input shared by all paginated admin lists.
+export interface PaginationRequest {
+  limit?: number | null;
+  page?: number | null;
+}
+
+// AdminLoginRequest authenticates the admin and establishes a session cookie.
+export interface AdminLoginRequest {
+  admin_secret: string;
+}
+
+// AdminMeta is admin-only configuration metadata (configured roles).
+export interface AdminMeta {
+  roles: string[];
+  default_roles: string[];
+  protected_roles: string[];
+}
+
+// PaginatedRequest wraps the pagination input for list queries.
+export interface PaginatedRequest {
+  pagination?: PaginationRequest | null;
+}
+
+// GetUserRequest fetches a single user by id or email (at least one required).
+export interface GetUserRequest {
+  id?: string | null;
+  email?: string | null;
+}
+
+// UpdateAccessRequest targets a single user id for revoke / enable access.
+export interface UpdateAccessRequest {
+  user_id: string;
+}
+
+// InviteMemberRequest invites a list of emails (requires a configured email service).
+export interface InviteMemberRequest {
+  emails: string[];
+  redirect_uri?: string | null;
+}
+
+// Webhook mirrors the server Webhook model.
+export interface Webhook {
+  id: string;
+  event_name: string | null;
+  event_description: string | null;
+  endpoint: string | null;
+  enabled: boolean | null;
+  headers: Record<string, any> | null;
+  created_at: number | null;
+  updated_at: number | null;
+}
+
+// Webhooks is a paginated list of webhooks.
+export interface Webhooks {
+  pagination: Pagination;
+  webhooks: Webhook[];
+}
+
+// WebhookLog mirrors the server WebhookLog model.
+export interface WebhookLog {
+  id: string;
+  http_status: number | null;
+  response: string | null;
+  request: string | null;
+  webhook_id: string | null;
+  created_at: number | null;
+  updated_at: number | null;
+}
+
+// WebhookLogs is a paginated list of webhook delivery logs.
+export interface WebhookLogs {
+  pagination: Pagination;
+  webhook_logs: WebhookLog[];
+}
+
+// AddWebhookRequest registers a new webhook.
+export interface AddWebhookRequest {
+  event_name: string;
+  event_description?: string | null;
+  endpoint: string;
+  enabled: boolean;
+  headers?: Record<string, any> | null;
+}
+
+// UpdateWebhookRequest updates an existing webhook.
+export interface UpdateWebhookRequest {
+  id: string;
+  event_name?: string | null;
+  event_description?: string | null;
+  endpoint?: string | null;
+  enabled?: boolean | null;
+  headers?: Record<string, any> | null;
+}
+
+// WebhookRequest targets a single webhook by id (get / delete).
+export interface WebhookRequest {
+  id: string;
+}
+
+// ListWebhookLogRequest is a paginated, optionally-filtered webhook-log read.
+export interface ListWebhookLogRequest {
+  pagination?: PaginationRequest | null;
+  webhook_id?: string | null;
+}
+
+// TestEndpointRequest sends a synthetic event payload to an endpoint.
+export interface TestEndpointRequest {
+  endpoint: string;
+  event_name: string;
+  event_description?: string | null;
+  headers?: Record<string, any> | null;
+}
+
+// TestEndpointResponse carries the endpoint's HTTP status + body.
+export interface TestEndpointResponse {
+  http_status: number | null;
+  response: string | null;
+}
+
+// EmailTemplate mirrors the server EmailTemplate model.
+export interface EmailTemplate {
+  id: string;
+  event_name: string;
+  template: string;
+  design: string;
+  subject: string;
+  created_at: number | null;
+  updated_at: number | null;
+}
+
+// EmailTemplates is a paginated list of email templates.
+export interface EmailTemplates {
+  pagination: Pagination;
+  email_templates: EmailTemplate[];
+}
+
+// AddEmailTemplateRequest creates a new email template.
+export interface AddEmailTemplateRequest {
+  event_name: string;
+  subject: string;
+  template: string;
+  design?: string | null;
+}
+
+// UpdateEmailTemplateRequest updates an existing email template.
+export interface UpdateEmailTemplateRequest {
+  id: string;
+  event_name?: string | null;
+  template?: string | null;
+  subject?: string | null;
+  design?: string | null;
+}
+
+// DeleteEmailTemplateRequest targets a single email template id.
+export interface DeleteEmailTemplateRequest {
+  id: string;
+}
+
+// AuditLog mirrors the server AuditLog model.
+export interface AuditLog {
+  id: string;
+  actor_id: string | null;
+  actor_type: string | null;
+  actor_email: string | null;
+  action: string | null;
+  resource_type: string | null;
+  resource_id: string | null;
+  ip_address: string | null;
+  user_agent: string | null;
+  metadata: string | null;
+  created_at: number | null;
+}
+
+// AuditLogs is a paginated list of audit log entries.
+export interface AuditLogs {
+  pagination: Pagination;
+  audit_logs: AuditLog[];
+}
+
+// ListAuditLogRequest is a paginated, optionally-filtered audit-log read.
+export interface ListAuditLogRequest {
+  pagination?: PaginationRequest | null;
+  action?: string | null;
+  actor_id?: string | null;
+  resource_type?: string | null;
+  resource_id?: string | null;
+  from_timestamp?: number | null;
+  to_timestamp?: number | null;
+}
+
+// FgaModel is a fine-grained authorization model (id + DSL form).
+export interface FgaModel {
+  id: string;
+  dsl: string;
+}
+
+// FgaTuple is one persisted relationship tuple.
+export interface FgaTuple {
+  user: string;
+  relation: string;
+  object: string;
+}
+
+// FgaTuples is a page of tuples plus a continuation token (empty when exhausted).
+export interface FgaTuples {
+  tuples: FgaTuple[];
+  continuation_token: string | null;
+}
+
+// FgaWriteModelInput installs a new authorization model from its DSL form.
+export interface FgaWriteModelInput {
+  dsl: string;
+}
+
+// FgaWriteTuplesInput is used for both writing and deleting tuples.
+export interface FgaWriteTuplesInput {
+  tuples: FgaTupleInput[];
+}
+
+// FgaReadTuplesInput is a paginated, optionally-filtered tuple read.
+export interface FgaReadTuplesInput {
+  user?: string | null;
+  relation?: string | null;
+  object?: string | null;
+  page_size?: number | null;
+  continuation_token?: string | null;
+}
+
+// FgaListUsersInput asks "which users of user_type have relation on object?".
+export interface FgaListUsersInput {
+  object: string;
+  relation: string;
+  user_type: string;
+}
+
+// FgaListUsersResponse lists fully-qualified user ids.
+export interface FgaListUsersResponse {
+  users: string[];
+}
+
+// FgaExpandInput asks for the relationship/userset tree of (relation, object).
+export interface FgaExpandInput {
+  relation: string;
+  object: string;
+}
+
+// FgaExpandResponse is the OpenFGA relationship/userset tree as a JSON string.
+export interface FgaExpandResponse {
+  tree: string;
+}
+
+// GenerateJWTKeysRequest requests a fresh key pair / secret of the given type.
+export interface GenerateJWTKeysRequest {
+  type: string;
+}
+
+// GenerateJWTKeysResponse carries the generated secret / key pair.
+export interface GenerateJWTKeysResponse {
+  secret: string | null;
+  public_key: string | null;
+  private_key: string | null;
+}
+
+// AdminSignupRequest sets the admin secret on a fresh deployment (gql-only).
+export interface AdminSignupRequest {
+  admin_secret: string;
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -6,6 +6,49 @@ import { AuthorizeResponse } from './types';
 
 export const hasWindow = (): boolean => typeof window !== 'undefined';
 
+// proto-gateway REST (protojson) serializes int64/uint64 fields as JSON STRINGS
+// (e.g. created_at "1781590366", pagination limit "10"), while the GraphQL path
+// returns them as numbers. These field names are the int64-typed fields across
+// the public + admin SDK surface; we coerce them back to numbers on REST
+// responses so both protocols return identically-shaped, number-typed objects.
+const INT64_FIELDS = new Set([
+  'created_at',
+  'updated_at',
+  'revoked_timestamp',
+  'expires_in',
+  'expires',
+  'limit',
+  'page',
+  'offset',
+  'total',
+  'from_timestamp',
+  'to_timestamp',
+]);
+
+// coerceInt64Fields walks a parsed REST response and converts known int64
+// fields from numeric strings to numbers in place, recursing through nested
+// objects and arrays. Non-numeric strings and other types are left untouched.
+export const coerceInt64Fields = (value: any): any => {
+  if (Array.isArray(value)) {
+    value.forEach(coerceInt64Fields);
+    return value;
+  }
+  if (value && typeof value === 'object') {
+    for (const key of Object.keys(value)) {
+      const v = value[key];
+      if (
+        INT64_FIELDS.has(key) &&
+        typeof v === 'string' &&
+        v !== '' &&
+        !Number.isNaN(Number(v))
+      )
+        value[key] = Number(v);
+      else if (v && typeof v === 'object') coerceInt64Fields(v);
+    }
+  }
+  return value;
+};
+
 export const trimURL = (url: string): string => {
   let trimmedData = url.trim();
   const lastChar = trimmedData[trimmedData.length - 1];


### PR DESCRIPTION
## What

- **Admin API client** (`AuthorizerAdmin`) covering the full `AuthorizerAdminService` surface: admin auth/session/meta, users, access, webhooks, email templates, audit logs, and FGA admin. Auth via `x-authorizer-admin-secret`.
- **Protocol selection** on the public client: `graphql` (default) and `rest`. gRPC is not available in JS (browser/Node) and throws a clear error.

## Why

Server 2.3.0-rc.9 (#635) serves all auth ops over REST with a flat response envelope identical to GraphQL, so the SDK can offer protocol choice and a typed admin surface.

## Notes

- Per-method protocol availability: rest-only admin ops (AdminLogout/Session/Meta, FgaGetModel/FgaReset) and gql-only extras (adminSignup/updateEnv/generateJWTKeys) raise a clear error on the unsupported transport.
- Flat rc.9 envelope: REST and GraphQL return identical SDK shapes.
- testcontainers integration tests across graphql + rest; CI image -> `quay.io/authorizer/authorizer:2.3.0-rc.9`; adds `examples/manual_test.ts`.