### PR TITLE
feat: machine-agent-identity grants and admin surface

### DIFF
--- a/__test__/tokenGrants.test.ts
+++ b/__test__/tokenGrants.test.ts
@@ -29,7 +29,14 @@ function mockJsonResponse(body: unknown, ok = true, status = 200) {
 
 function lastRequest(): { url: string; init: RequestInit; body: any } {
   const [url, init] = fetchMock.mock.calls[fetchMock.mock.calls.length - 1];
-  return { url, init, body: JSON.parse(init.body as string) };
+  const raw = init.body as string;
+  const contentType = (init.headers as Record<string, string>)['Content-Type'];
+  // /oauth/token requests are form-encoded (RFC 6749); everything else is JSON
+  const body =
+    contentType === 'application/x-www-form-urlencoded'
+      ? Object.fromEntries(new URLSearchParams(raw))
+      : JSON.parse(raw);
+  return { url, init, body };
 }
 
 beforeEach(() => fetchMock.mockReset());
@@ -56,8 +63,12 @@ describe('getToken machine grants', () => {
     expect(res.errors).toHaveLength(0);
     expect(res.data?.access_token).toBe('at');
 
-    const { url, body } = lastRequest();
+    const { url, init, body } = lastRequest();
     expect(url).toBe('http://localhost:8080/oauth/token');
+    // must be form-encoded: the server reads `resource` only from the POST form
+    expect((init.headers as Record<string, string>)['Content-Type']).toBe(
+      'application/x-www-form-urlencoded',
+    );
     expect(body).toEqual({
       client_id: 'test-client-id',
       grant_type: GRANT_TYPE_CLIENT_CREDENTIALS,

--- a/__test__/tokenGrants.test.ts
+++ b/__test__/tokenGrants.test.ts
@@ -1,0 +1,247 @@
+// Unit tests (no docker) for the machine-agent-identity surface: the
+// client_credentials / RFC 8693 token-exchange grants on getToken, and the
+// new admin methods' request construction. cross-fetch is mocked so we can
+// assert the exact request bodies sent to the server.
+import crossFetch from 'cross-fetch';
+import {
+  Authorizer,
+  AuthorizerAdmin,
+  GRANT_TYPE_CLIENT_CREDENTIALS,
+  GRANT_TYPE_TOKEN_EXCHANGE,
+  CLIENT_ASSERTION_TYPE_JWT_BEARER,
+  TOKEN_TYPE_ACCESS_TOKEN,
+} from '../src';
+
+jest.mock('cross-fetch', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+const fetchMock = crossFetch as unknown as jest.Mock;
+
+function mockJsonResponse(body: unknown, ok = true, status = 200) {
+  fetchMock.mockResolvedValueOnce({
+    ok,
+    status,
+    text: async () => JSON.stringify(body),
+  });
+}
+
+function lastRequest(): { url: string; init: RequestInit; body: any } {
+  const [url, init] = fetchMock.mock.calls[fetchMock.mock.calls.length - 1];
+  return { url, init, body: JSON.parse(init.body as string) };
+}
+
+beforeEach(() => fetchMock.mockReset());
+
+describe('getToken machine grants', () => {
+  const authorizer = new Authorizer({
+    authorizerURL: 'http://localhost:8080',
+    redirectURL: 'http://localhost:8080/app',
+    clientID: 'test-client-id',
+  });
+
+  it('sends client_secret + scope for client_credentials and omits unset params', async () => {
+    mockJsonResponse({
+      access_token: 'at',
+      token_type: 'Bearer',
+      expires_in: 900,
+      scope: 'read:users',
+    });
+    const res = await authorizer.getToken({
+      grant_type: GRANT_TYPE_CLIENT_CREDENTIALS,
+      client_secret: 'sa-secret',
+      scope: 'read:users',
+    });
+    expect(res.errors).toHaveLength(0);
+    expect(res.data?.access_token).toBe('at');
+
+    const { url, body } = lastRequest();
+    expect(url).toBe('http://localhost:8080/oauth/token');
+    expect(body).toEqual({
+      client_id: 'test-client-id',
+      grant_type: GRANT_TYPE_CLIENT_CREDENTIALS,
+      client_secret: 'sa-secret',
+      scope: 'read:users',
+    });
+    // legacy params must not be sent on machine grants
+    expect(body).not.toHaveProperty('code');
+    expect(body).not.toHaveProperty('code_verifier');
+    expect(body).not.toHaveProperty('refresh_token');
+  });
+
+  it('sends client_assertion for secretless client_credentials', async () => {
+    mockJsonResponse({ access_token: 'at', expires_in: 900 });
+    await authorizer.getToken({
+      grant_type: GRANT_TYPE_CLIENT_CREDENTIALS,
+      client_assertion: 'k8s-sa-jwt',
+      client_assertion_type: CLIENT_ASSERTION_TYPE_JWT_BEARER,
+    });
+
+    const { body } = lastRequest();
+    expect(body.client_assertion).toBe('k8s-sa-jwt');
+    expect(body.client_assertion_type).toBe(CLIENT_ASSERTION_TYPE_JWT_BEARER);
+    expect(body).not.toHaveProperty('client_secret');
+  });
+
+  it('sends the RFC 8693 params for token exchange', async () => {
+    mockJsonResponse({
+      access_token: 'delegated',
+      issued_token_type: TOKEN_TYPE_ACCESS_TOKEN,
+      token_type: 'Bearer',
+      expires_in: 300,
+      scope: 'read:docs',
+    });
+    const res = await authorizer.getToken({
+      grant_type: GRANT_TYPE_TOKEN_EXCHANGE,
+      client_secret: 'agent-secret',
+      subject_token: 'user-at',
+      subject_token_type: TOKEN_TYPE_ACCESS_TOKEN,
+      actor_token: 'agent-at',
+      actor_token_type: TOKEN_TYPE_ACCESS_TOKEN,
+      resource: 'https://api.example.com',
+      scope: 'read:docs',
+    });
+    expect(res.errors).toHaveLength(0);
+    expect(res.data?.issued_token_type).toBe(TOKEN_TYPE_ACCESS_TOKEN);
+
+    const { body } = lastRequest();
+    expect(body).toEqual({
+      client_id: 'test-client-id',
+      grant_type: GRANT_TYPE_TOKEN_EXCHANGE,
+      client_secret: 'agent-secret',
+      subject_token: 'user-at',
+      subject_token_type: TOKEN_TYPE_ACCESS_TOKEN,
+      actor_token: 'agent-at',
+      actor_token_type: TOKEN_TYPE_ACCESS_TOKEN,
+      resource: 'https://api.example.com',
+      scope: 'read:docs',
+    });
+  });
+
+  it('rejects token exchange without subject_token before any request', async () => {
+    const res = await authorizer.getToken({
+      grant_type: GRANT_TYPE_TOKEN_EXCHANGE,
+      client_secret: 'agent-secret',
+    });
+    expect(res.errors[0].message).toBe('Invalid subject_token');
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('still sends refresh_token grant unchanged (regression)', async () => {
+    mockJsonResponse({ access_token: 'at', expires_in: 900, id_token: 'idt' });
+    await authorizer.getToken({
+      grant_type: 'refresh_token',
+      refresh_token: 'rt',
+    });
+    const { body } = lastRequest();
+    expect(body).toEqual({
+      client_id: 'test-client-id',
+      grant_type: 'refresh_token',
+      refresh_token: 'rt',
+    });
+  });
+
+  it('surfaces the OAuth error_description on failure', async () => {
+    mockJsonResponse(
+      {
+        error: 'invalid_client',
+        error_description: 'Client authentication failed',
+      },
+      false,
+      401,
+    );
+    const res = await authorizer.getToken({
+      grant_type: GRANT_TYPE_CLIENT_CREDENTIALS,
+      client_secret: 'bad',
+    });
+    expect(res.errors[0].message).toBe('Client authentication failed');
+  });
+});
+
+describe('AuthorizerAdmin machine-agent-identity methods', () => {
+  const adminConfig = {
+    authorizerURL: 'http://localhost:8080',
+    adminSecret: 'secret',
+  };
+
+  it('createClient posts the _create_client mutation over graphql', async () => {
+    const admin = new AuthorizerAdmin(adminConfig);
+    mockJsonResponse({
+      data: {
+        _create_client: {
+          client: { id: 'c1', name: 'svc', allowed_scopes: ['read:users'] },
+          client_secret: 'once',
+        },
+      },
+    });
+    const res = await admin.createClient({
+      name: 'svc',
+      allowed_scopes: ['read:users'],
+    });
+    expect(res.errors).toHaveLength(0);
+    expect(res.data?.client_secret).toBe('once');
+
+    const { url, init, body } = lastRequest();
+    expect(url).toBe('http://localhost:8080/graphql');
+    expect(
+      (init.headers as Record<string, string>)['x-authorizer-admin-secret'],
+    ).toBe('secret');
+    expect(body.operationName).toBe('_create_client');
+    expect(body.variables).toEqual({
+      params: { name: 'svc', allowed_scopes: ['read:users'] },
+    });
+  });
+
+  it('trustedIssuers hits the mapped REST route over rest protocol', async () => {
+    const admin = new AuthorizerAdmin({ ...adminConfig, protocol: 'rest' });
+    mockJsonResponse({
+      trusted_issuers: [],
+      pagination: { limit: '10', page: '1', offset: '0', total: '0' },
+    });
+    const res = await admin.trustedIssuers({
+      service_account_id: 'sa1',
+    });
+    expect(res.errors).toHaveLength(0);
+    // int64 strings from the proto gateway are coerced to numbers
+    expect(res.data?.pagination.total).toBe(0);
+
+    const { url, body } = lastRequest();
+    expect(url).toBe('http://localhost:8080/v1/admin/trusted_issuers');
+    expect(body).toEqual({ service_account_id: 'sa1' });
+  });
+
+  it('client unwraps the proto-gateway wrapper over rest', async () => {
+    const admin = new AuthorizerAdmin({ ...adminConfig, protocol: 'rest' });
+    mockJsonResponse({ client: { id: 'c1', name: 'svc' } });
+    const res = await admin.client({ id: 'c1' });
+    expect(res.data).toEqual({ id: 'c1', name: 'svc' });
+    expect(lastRequest().url).toBe('http://localhost:8080/v1/admin/client');
+  });
+
+  it('graphql-only org methods refuse the rest protocol with a clear error', async () => {
+    const admin = new AuthorizerAdmin({ ...adminConfig, protocol: 'rest' });
+    const res = await admin.createOrganization({ name: 'acme' });
+    expect(res.errors[0].message).toBe(
+      'CreateOrganization is not available over rest; supported: graphql',
+    );
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('createScimEndpoint posts the _create_scim_endpoint mutation', async () => {
+    const admin = new AuthorizerAdmin(adminConfig);
+    mockJsonResponse({
+      data: {
+        _create_scim_endpoint: {
+          scim_endpoint: { id: 's1', org_id: 'o1', enabled: true },
+          token: 'bearer-once',
+        },
+      },
+    });
+    const res = await admin.createScimEndpoint({ org_id: 'o1' });
+    expect(res.data?.token).toBe('bearer-once');
+    const { body } = lastRequest();
+    expect(body.operationName).toBe('_create_scim_endpoint');
+    expect(body.variables).toEqual({ params: { org_id: 'o1' } });
+  });
+});

--- a/src/admin.ts
+++ b/src/admin.ts
@@ -18,6 +18,18 @@ const emailTemplateFragment =
   'id event_name template design subject created_at updated_at';
 const auditLogFragment =
   'id actor_id actor_type actor_email action resource_type resource_id ip_address user_agent metadata created_at';
+const clientFragment =
+  'id name description allowed_scopes is_active created_at updated_at';
+const trustedIssuerFragment =
+  'id service_account_id name issuer_url key_source_type jwks_url expected_aud subject_claim allowed_subjects issuer_type is_active spiffe_refresh_hint_seconds created_at updated_at';
+const organizationFragment =
+  'id name display_name enabled created_at updated_at';
+const orgMemberFragment = 'id org_id user_id roles created_at updated_at';
+const orgOIDCConnectionFragment =
+  'id org_id name issuer_url sso_client_id scopes redirect_uri is_active created_at updated_at';
+const orgSAMLConnectionFragment =
+  'id org_id name idp_entity_id idp_sso_url sp_entity_id acs_url attribute_mapping allow_idp_initiated is_active created_at updated_at';
+const scimEndpointFragment = 'id org_id enabled created_at updated_at';
 
 function toErrorList(errors: unknown): Error[] {
   if (Array.isArray(errors)) {
@@ -780,6 +792,559 @@ export class AuthorizerAdmin {
       ['rest'],
       null,
       { method: 'POST', path: '/v1/admin/fga/reset' },
+    );
+
+  // ---- OAuth clients (service accounts) ----
+
+  // createClient registers a new OAuth client / service account. The returned
+  // client_secret is shown ONCE and can never be retrieved again.
+  createClient = (
+    params: Types.CreateClientRequest,
+  ): Promise<Types.ApiResponse<Types.CreateClientResponse>> =>
+    this.dispatch<Types.CreateClientResponse>(
+      'CreateClient',
+      ['graphql', 'rest'],
+      {
+        query: `mutation _create_client($params: CreateClientRequest!) { _create_client(params: $params) { client { ${clientFragment} } client_secret } }`,
+        operationName: '_create_client',
+        op: '_create_client',
+      },
+      { method: 'POST', path: '/v1/admin/create_client' },
+      { params },
+      params as unknown as Record<string, unknown>,
+    );
+
+  // updateClient updates a client's name, description, scopes, or active state.
+  updateClient = (
+    params: Types.UpdateClientRequest,
+  ): Promise<Types.ApiResponse<Types.Client>> =>
+    this.dispatch<Types.Client>(
+      'UpdateClient',
+      ['graphql', 'rest'],
+      {
+        query: `mutation _update_client($params: UpdateClientRequest!) { _update_client(params: $params) { ${clientFragment} } }`,
+        operationName: '_update_client',
+        op: '_update_client',
+      },
+      { method: 'POST', path: '/v1/admin/update_client', unwrap: 'client' },
+      { params },
+      params as unknown as Record<string, unknown>,
+    );
+
+  // deleteClient deletes a client by id. DESTRUCTIVE: the client and its
+  // credential are permanently removed.
+  deleteClient = (
+    params: Types.ClientRequest,
+  ): Promise<Types.ApiResponse<Types.Response>> =>
+    this.dispatch<Types.Response>(
+      'DeleteClient',
+      ['graphql', 'rest'],
+      {
+        query:
+          'mutation _delete_client($params: ClientRequest!) { _delete_client(params: $params) { message } }',
+        operationName: '_delete_client',
+        op: '_delete_client',
+      },
+      { method: 'POST', path: '/v1/admin/delete_client' },
+      { params },
+      params as unknown as Record<string, unknown>,
+    );
+
+  // rotateClientSecret mints a fresh secret for the client. The new secret is
+  // shown ONCE; the old secret stops working immediately.
+  rotateClientSecret = (
+    params: Types.ClientRequest,
+  ): Promise<Types.ApiResponse<Types.CreateClientResponse>> =>
+    this.dispatch<Types.CreateClientResponse>(
+      'RotateClientSecret',
+      ['graphql', 'rest'],
+      {
+        query: `mutation _rotate_client_secret($params: ClientRequest!) { _rotate_client_secret(params: $params) { client { ${clientFragment} } client_secret } }`,
+        operationName: '_rotate_client_secret',
+        op: '_rotate_client_secret',
+      },
+      { method: 'POST', path: '/v1/admin/rotate_client_secret' },
+      { params },
+      params as unknown as Record<string, unknown>,
+    );
+
+  // client returns a single client by id (never includes the secret).
+  client = (
+    params: Types.ClientRequest,
+  ): Promise<Types.ApiResponse<Types.Client>> =>
+    this.dispatch<Types.Client>(
+      'GetClient',
+      ['graphql', 'rest'],
+      {
+        query: `query _client($params: ClientRequest!) { _client(params: $params) { ${clientFragment} } }`,
+        operationName: '_client',
+        op: '_client',
+      },
+      { method: 'POST', path: '/v1/admin/client', unwrap: 'client' },
+      { params },
+      params as unknown as Record<string, unknown>,
+    );
+
+  // clients returns a paginated list of clients.
+  clients = (
+    params?: Types.ListClientsRequest,
+  ): Promise<Types.ApiResponse<Types.Clients>> =>
+    this.dispatch<Types.Clients>(
+      'Clients',
+      ['graphql', 'rest'],
+      {
+        query: `query _clients($params: ListClientsRequest) { _clients(params: $params) { pagination { ${paginationFragment} } clients { ${clientFragment} } } }`,
+        operationName: '_clients',
+        op: '_clients',
+      },
+      { method: 'POST', path: '/v1/admin/clients' },
+      { params },
+      (params || {}) as Record<string, unknown>,
+    );
+
+  // ---- Trusted issuers (secretless client authentication) ----
+
+  // addTrustedIssuer registers an external token issuer trusted to
+  // authenticate a service account via RFC 7523 client_assertion.
+  addTrustedIssuer = (
+    params: Types.AddTrustedIssuerRequest,
+  ): Promise<Types.ApiResponse<Types.TrustedIssuer>> =>
+    this.dispatch<Types.TrustedIssuer>(
+      'AddTrustedIssuer',
+      ['graphql', 'rest'],
+      {
+        query: `mutation _add_trusted_issuer($params: AddTrustedIssuerRequest!) { _add_trusted_issuer(params: $params) { ${trustedIssuerFragment} } }`,
+        operationName: '_add_trusted_issuer',
+        op: '_add_trusted_issuer',
+      },
+      {
+        method: 'POST',
+        path: '/v1/admin/add_trusted_issuer',
+        unwrap: 'trusted_issuer',
+      },
+      { params },
+      params as unknown as Record<string, unknown>,
+    );
+
+  // updateTrustedIssuer updates an existing trusted issuer.
+  updateTrustedIssuer = (
+    params: Types.UpdateTrustedIssuerRequest,
+  ): Promise<Types.ApiResponse<Types.TrustedIssuer>> =>
+    this.dispatch<Types.TrustedIssuer>(
+      'UpdateTrustedIssuer',
+      ['graphql', 'rest'],
+      {
+        query: `mutation _update_trusted_issuer($params: UpdateTrustedIssuerRequest!) { _update_trusted_issuer(params: $params) { ${trustedIssuerFragment} } }`,
+        operationName: '_update_trusted_issuer',
+        op: '_update_trusted_issuer',
+      },
+      {
+        method: 'POST',
+        path: '/v1/admin/update_trusted_issuer',
+        unwrap: 'trusted_issuer',
+      },
+      { params },
+      params as unknown as Record<string, unknown>,
+    );
+
+  // deleteTrustedIssuer deletes a trusted issuer by id. DESTRUCTIVE: tokens
+  // from that issuer stop authenticating immediately.
+  deleteTrustedIssuer = (
+    params: Types.TrustedIssuerRequest,
+  ): Promise<Types.ApiResponse<Types.Response>> =>
+    this.dispatch<Types.Response>(
+      'DeleteTrustedIssuer',
+      ['graphql', 'rest'],
+      {
+        query:
+          'mutation _delete_trusted_issuer($params: TrustedIssuerRequest!) { _delete_trusted_issuer(params: $params) { message } }',
+        operationName: '_delete_trusted_issuer',
+        op: '_delete_trusted_issuer',
+      },
+      { method: 'POST', path: '/v1/admin/delete_trusted_issuer' },
+      { params },
+      params as unknown as Record<string, unknown>,
+    );
+
+  // trustedIssuer returns a single trusted issuer by id.
+  trustedIssuer = (
+    params: Types.TrustedIssuerRequest,
+  ): Promise<Types.ApiResponse<Types.TrustedIssuer>> =>
+    this.dispatch<Types.TrustedIssuer>(
+      'GetTrustedIssuer',
+      ['graphql', 'rest'],
+      {
+        query: `query _trusted_issuer($params: TrustedIssuerRequest!) { _trusted_issuer(params: $params) { ${trustedIssuerFragment} } }`,
+        operationName: '_trusted_issuer',
+        op: '_trusted_issuer',
+      },
+      {
+        method: 'POST',
+        path: '/v1/admin/trusted_issuer',
+        unwrap: 'trusted_issuer',
+      },
+      { params },
+      params as unknown as Record<string, unknown>,
+    );
+
+  // trustedIssuers returns a paginated list of trusted issuers, optionally
+  // filtered by service account.
+  trustedIssuers = (
+    params?: Types.ListTrustedIssuersRequest,
+  ): Promise<Types.ApiResponse<Types.TrustedIssuers>> =>
+    this.dispatch<Types.TrustedIssuers>(
+      'TrustedIssuers',
+      ['graphql', 'rest'],
+      {
+        query: `query _trusted_issuers($params: ListTrustedIssuersRequest) { _trusted_issuers(params: $params) { pagination { ${paginationFragment} } trusted_issuers { ${trustedIssuerFragment} } } }`,
+        operationName: '_trusted_issuers',
+        op: '_trusted_issuers',
+      },
+      { method: 'POST', path: '/v1/admin/trusted_issuers' },
+      { params },
+      (params || {}) as Record<string, unknown>,
+    );
+
+  // ---- Organizations (graphql-only: no proto/REST routes yet) ----
+
+  // createOrganization creates a new organization.
+  createOrganization = (
+    params: Types.CreateOrganizationRequest,
+  ): Promise<Types.ApiResponse<Types.Organization>> =>
+    this.dispatch<Types.Organization>(
+      'CreateOrganization',
+      ['graphql'],
+      {
+        query: `mutation _create_organization($params: CreateOrganizationRequest!) { _create_organization(params: $params) { ${organizationFragment} } }`,
+        operationName: '_create_organization',
+        op: '_create_organization',
+      },
+      null,
+      { params },
+    );
+
+  // updateOrganization updates an existing organization.
+  updateOrganization = (
+    params: Types.UpdateOrganizationRequest,
+  ): Promise<Types.ApiResponse<Types.Organization>> =>
+    this.dispatch<Types.Organization>(
+      'UpdateOrganization',
+      ['graphql'],
+      {
+        query: `mutation _update_organization($params: UpdateOrganizationRequest!) { _update_organization(params: $params) { ${organizationFragment} } }`,
+        operationName: '_update_organization',
+        op: '_update_organization',
+      },
+      null,
+      { params },
+    );
+
+  // deleteOrganization deletes an organization by id. DESTRUCTIVE.
+  deleteOrganization = (
+    params: Types.OrganizationRequest,
+  ): Promise<Types.ApiResponse<Types.Response>> =>
+    this.dispatch<Types.Response>(
+      'DeleteOrganization',
+      ['graphql'],
+      {
+        query:
+          'mutation _delete_organization($params: OrganizationRequest!) { _delete_organization(params: $params) { message } }',
+        operationName: '_delete_organization',
+        op: '_delete_organization',
+      },
+      null,
+      { params },
+    );
+
+  // addOrgMember adds a user to an organization with optional per-org roles.
+  addOrgMember = (
+    params: Types.AddOrgMemberRequest,
+  ): Promise<Types.ApiResponse<Types.OrgMember>> =>
+    this.dispatch<Types.OrgMember>(
+      'AddOrgMember',
+      ['graphql'],
+      {
+        query: `mutation _add_org_member($params: AddOrgMemberRequest!) { _add_org_member(params: $params) { ${orgMemberFragment} } }`,
+        operationName: '_add_org_member',
+        op: '_add_org_member',
+      },
+      null,
+      { params },
+    );
+
+  // removeOrgMember removes a user from an organization.
+  removeOrgMember = (
+    params: Types.RemoveOrgMemberRequest,
+  ): Promise<Types.ApiResponse<Types.Response>> =>
+    this.dispatch<Types.Response>(
+      'RemoveOrgMember',
+      ['graphql'],
+      {
+        query:
+          'mutation _remove_org_member($params: RemoveOrgMemberRequest!) { _remove_org_member(params: $params) { message } }',
+        operationName: '_remove_org_member',
+        op: '_remove_org_member',
+      },
+      null,
+      { params },
+    );
+
+  // organization returns a single organization by id.
+  organization = (
+    params: Types.OrganizationRequest,
+  ): Promise<Types.ApiResponse<Types.Organization>> =>
+    this.dispatch<Types.Organization>(
+      'GetOrganization',
+      ['graphql'],
+      {
+        query: `query _organization($params: OrganizationRequest!) { _organization(params: $params) { ${organizationFragment} } }`,
+        operationName: '_organization',
+        op: '_organization',
+      },
+      null,
+      { params },
+    );
+
+  // organizations returns a paginated list of organizations.
+  organizations = (
+    params?: Types.ListOrganizationsRequest,
+  ): Promise<Types.ApiResponse<Types.Organizations>> =>
+    this.dispatch<Types.Organizations>(
+      'Organizations',
+      ['graphql'],
+      {
+        query: `query _organizations($params: ListOrganizationsRequest) { _organizations(params: $params) { pagination { ${paginationFragment} } organizations { ${organizationFragment} } } }`,
+        operationName: '_organizations',
+        op: '_organizations',
+      },
+      null,
+      { params },
+    );
+
+  // orgMembers returns a paginated list of an organization's members.
+  orgMembers = (
+    params: Types.ListOrgMembersRequest,
+  ): Promise<Types.ApiResponse<Types.OrgMembers>> =>
+    this.dispatch<Types.OrgMembers>(
+      'OrgMembers',
+      ['graphql'],
+      {
+        query: `query _org_members($params: ListOrgMembersRequest!) { _org_members(params: $params) { pagination { ${paginationFragment} } org_members { ${orgMemberFragment} } } }`,
+        operationName: '_org_members',
+        op: '_org_members',
+      },
+      null,
+      { params },
+    );
+
+  // ---- Org SSO connections (graphql-only: no proto/REST routes yet) ----
+
+  // createOrgOIDCConnection registers a per-org upstream OIDC IdP (Authorizer
+  // as Relying Party). The upstream client_secret is stored encrypted and
+  // never returned.
+  createOrgOIDCConnection = (
+    params: Types.CreateOrgOIDCConnectionRequest,
+  ): Promise<Types.ApiResponse<Types.OrgOIDCConnection>> =>
+    this.dispatch<Types.OrgOIDCConnection>(
+      'CreateOrgOIDCConnection',
+      ['graphql'],
+      {
+        query: `mutation _create_org_oidc_connection($params: CreateOrgOIDCConnectionRequest!) { _create_org_oidc_connection(params: $params) { ${orgOIDCConnectionFragment} } }`,
+        operationName: '_create_org_oidc_connection',
+        op: '_create_org_oidc_connection',
+      },
+      null,
+      { params },
+    );
+
+  // updateOrgOIDCConnection updates a per-org upstream OIDC connection.
+  updateOrgOIDCConnection = (
+    params: Types.UpdateOrgOIDCConnectionRequest,
+  ): Promise<Types.ApiResponse<Types.OrgOIDCConnection>> =>
+    this.dispatch<Types.OrgOIDCConnection>(
+      'UpdateOrgOIDCConnection',
+      ['graphql'],
+      {
+        query: `mutation _update_org_oidc_connection($params: UpdateOrgOIDCConnectionRequest!) { _update_org_oidc_connection(params: $params) { ${orgOIDCConnectionFragment} } }`,
+        operationName: '_update_org_oidc_connection',
+        op: '_update_org_oidc_connection',
+      },
+      null,
+      { params },
+    );
+
+  // deleteOrgOIDCConnection deletes a per-org upstream OIDC connection.
+  // DESTRUCTIVE: SSO via that IdP stops working immediately.
+  deleteOrgOIDCConnection = (
+    params: Types.OrgOIDCConnectionRequest,
+  ): Promise<Types.ApiResponse<Types.Response>> =>
+    this.dispatch<Types.Response>(
+      'DeleteOrgOIDCConnection',
+      ['graphql'],
+      {
+        query:
+          'mutation _delete_org_oidc_connection($params: OrgOIDCConnectionRequest!) { _delete_org_oidc_connection(params: $params) { message } }',
+        operationName: '_delete_org_oidc_connection',
+        op: '_delete_org_oidc_connection',
+      },
+      null,
+      { params },
+    );
+
+  // orgOIDCConnection returns a per-org upstream OIDC connection by id OR
+  // org_id (supply exactly one).
+  orgOIDCConnection = (
+    params: Types.OrgOIDCConnectionRequest,
+  ): Promise<Types.ApiResponse<Types.OrgOIDCConnection>> =>
+    this.dispatch<Types.OrgOIDCConnection>(
+      'GetOrgOIDCConnection',
+      ['graphql'],
+      {
+        query: `query _org_oidc_connection($params: OrgOIDCConnectionRequest!) { _org_oidc_connection(params: $params) { ${orgOIDCConnectionFragment} } }`,
+        operationName: '_org_oidc_connection',
+        op: '_org_oidc_connection',
+      },
+      null,
+      { params },
+    );
+
+  // createOrgSAMLConnection registers a per-org upstream SAML 2.0 IdP
+  // (Authorizer as Service Provider). The IdP certificate is accepted on
+  // write but never returned.
+  createOrgSAMLConnection = (
+    params: Types.CreateOrgSAMLConnectionRequest,
+  ): Promise<Types.ApiResponse<Types.OrgSAMLConnection>> =>
+    this.dispatch<Types.OrgSAMLConnection>(
+      'CreateOrgSAMLConnection',
+      ['graphql'],
+      {
+        query: `mutation _create_org_saml_connection($params: CreateOrgSAMLConnectionRequest!) { _create_org_saml_connection(params: $params) { ${orgSAMLConnectionFragment} } }`,
+        operationName: '_create_org_saml_connection',
+        op: '_create_org_saml_connection',
+      },
+      null,
+      { params },
+    );
+
+  // updateOrgSAMLConnection updates a per-org upstream SAML connection.
+  updateOrgSAMLConnection = (
+    params: Types.UpdateOrgSAMLConnectionRequest,
+  ): Promise<Types.ApiResponse<Types.OrgSAMLConnection>> =>
+    this.dispatch<Types.OrgSAMLConnection>(
+      'UpdateOrgSAMLConnection',
+      ['graphql'],
+      {
+        query: `mutation _update_org_saml_connection($params: UpdateOrgSAMLConnectionRequest!) { _update_org_saml_connection(params: $params) { ${orgSAMLConnectionFragment} } }`,
+        operationName: '_update_org_saml_connection',
+        op: '_update_org_saml_connection',
+      },
+      null,
+      { params },
+    );
+
+  // deleteOrgSAMLConnection deletes a per-org upstream SAML connection.
+  // DESTRUCTIVE: SSO via that IdP stops working immediately.
+  deleteOrgSAMLConnection = (
+    params: Types.OrgSAMLConnectionRequest,
+  ): Promise<Types.ApiResponse<Types.Response>> =>
+    this.dispatch<Types.Response>(
+      'DeleteOrgSAMLConnection',
+      ['graphql'],
+      {
+        query:
+          'mutation _delete_org_saml_connection($params: OrgSAMLConnectionRequest!) { _delete_org_saml_connection(params: $params) { message } }',
+        operationName: '_delete_org_saml_connection',
+        op: '_delete_org_saml_connection',
+      },
+      null,
+      { params },
+    );
+
+  // orgSAMLConnection returns a per-org upstream SAML connection by id OR
+  // org_id (supply exactly one).
+  orgSAMLConnection = (
+    params: Types.OrgSAMLConnectionRequest,
+  ): Promise<Types.ApiResponse<Types.OrgSAMLConnection>> =>
+    this.dispatch<Types.OrgSAMLConnection>(
+      'GetOrgSAMLConnection',
+      ['graphql'],
+      {
+        query: `query _org_saml_connection($params: OrgSAMLConnectionRequest!) { _org_saml_connection(params: $params) { ${orgSAMLConnectionFragment} } }`,
+        operationName: '_org_saml_connection',
+        op: '_org_saml_connection',
+      },
+      null,
+      { params },
+    );
+
+  // ---- SCIM endpoints (graphql-only: no proto/REST routes yet) ----
+
+  // createScimEndpoint provisions the org's inbound SCIM 2.0 endpoint. The
+  // returned bearer token is shown ONCE and can never be retrieved again.
+  createScimEndpoint = (
+    params: Types.CreateScimEndpointRequest,
+  ): Promise<Types.ApiResponse<Types.CreateScimEndpointResponse>> =>
+    this.dispatch<Types.CreateScimEndpointResponse>(
+      'CreateScimEndpoint',
+      ['graphql'],
+      {
+        query: `mutation _create_scim_endpoint($params: CreateScimEndpointRequest!) { _create_scim_endpoint(params: $params) { scim_endpoint { ${scimEndpointFragment} } token } }`,
+        operationName: '_create_scim_endpoint',
+        op: '_create_scim_endpoint',
+      },
+      null,
+      { params },
+    );
+
+  // rotateScimToken mints a fresh SCIM bearer token for the org. The new
+  // token is shown ONCE; the old token stops working immediately.
+  rotateScimToken = (
+    params: Types.ScimEndpointRequest,
+  ): Promise<Types.ApiResponse<Types.CreateScimEndpointResponse>> =>
+    this.dispatch<Types.CreateScimEndpointResponse>(
+      'RotateScimToken',
+      ['graphql'],
+      {
+        query: `mutation _rotate_scim_token($params: ScimEndpointRequest!) { _rotate_scim_token(params: $params) { scim_endpoint { ${scimEndpointFragment} } token } }`,
+        operationName: '_rotate_scim_token',
+        op: '_rotate_scim_token',
+      },
+      null,
+      { params },
+    );
+
+  // deleteScimEndpoint removes the org's SCIM endpoint. DESTRUCTIVE: inbound
+  // SCIM provisioning stops immediately.
+  deleteScimEndpoint = (
+    params: Types.ScimEndpointRequest,
+  ): Promise<Types.ApiResponse<Types.Response>> =>
+    this.dispatch<Types.Response>(
+      'DeleteScimEndpoint',
+      ['graphql'],
+      {
+        query:
+          'mutation _delete_scim_endpoint($params: ScimEndpointRequest!) { _delete_scim_endpoint(params: $params) { message } }',
+        operationName: '_delete_scim_endpoint',
+        op: '_delete_scim_endpoint',
+      },
+      null,
+      { params },
+    );
+
+  // scimEndpoint returns the org's SCIM endpoint (never includes the token).
+  scimEndpoint = (
+    params: Types.ScimEndpointRequest,
+  ): Promise<Types.ApiResponse<Types.ScimEndpoint>> =>
+    this.dispatch<Types.ScimEndpoint>(
+      'GetScimEndpoint',
+      ['graphql'],
+      {
+        query: `query _scim_endpoint($params: ScimEndpointRequest!) { _scim_endpoint(params: $params) { ${scimEndpointFragment} } }`,
+        operationName: '_scim_endpoint',
+        op: '_scim_endpoint',
+      },
+      null,
+      { params },
     );
 
   // ---- gql-only extras (no proto / no rest) ----

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,3 +1,21 @@
 export const DEFAULT_AUTHORIZE_TIMEOUT_IN_SECONDS = 60;
+
+// OAuth2 grant-type identifiers accepted by /oauth/token.
+// client_credentials (RFC 6749 §4.4) and token-exchange (RFC 8693) are
+// machine/service flows — server-side only.
+export const GRANT_TYPE_AUTHORIZATION_CODE = 'authorization_code';
+export const GRANT_TYPE_REFRESH_TOKEN = 'refresh_token';
+export const GRANT_TYPE_CLIENT_CREDENTIALS = 'client_credentials';
+export const GRANT_TYPE_TOKEN_EXCHANGE =
+  'urn:ietf:params:oauth:grant-type:token-exchange';
+
+// RFC 8693 token-type URNs for subject_token_type / actor_token_type.
+export const TOKEN_TYPE_ACCESS_TOKEN =
+  'urn:ietf:params:oauth:token-type:access_token';
+export const TOKEN_TYPE_JWT = 'urn:ietf:params:oauth:token-type:jwt';
+
+// RFC 7523 JWT-bearer client_assertion_type (secretless client auth).
+export const CLIENT_ASSERTION_TYPE_JWT_BEARER =
+  'urn:ietf:params:oauth:client-assertion-type:jwt-bearer';
 export const CLEANUP_IFRAME_TIMEOUT_IN_SECONDS = 2;
 export const AUTHORIZE_IFRAME_TIMEOUT = 5;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,9 @@
 // Note: write gql query in single line to reduce bundle size
 import crossFetch from 'cross-fetch';
-import { DEFAULT_AUTHORIZE_TIMEOUT_IN_SECONDS } from './constants';
+import {
+  DEFAULT_AUTHORIZE_TIMEOUT_IN_SECONDS,
+  GRANT_TYPE_TOKEN_EXCHANGE,
+} from './constants';
 import * as Types from './types';
 import {
   bufferToBase64UrlEncoded,
@@ -52,6 +55,15 @@ function toErrorList(errors: unknown): Error[] {
 
 export * from './types';
 export { AuthorizerAdmin } from './admin';
+export {
+  CLIENT_ASSERTION_TYPE_JWT_BEARER,
+  GRANT_TYPE_AUTHORIZATION_CODE,
+  GRANT_TYPE_CLIENT_CREDENTIALS,
+  GRANT_TYPE_REFRESH_TOKEN,
+  GRANT_TYPE_TOKEN_EXCHANGE,
+  TOKEN_TYPE_ACCESS_TOKEN,
+  TOKEN_TYPE_JWT,
+} from './constants';
 
 /**
  * Client for the Authorizer API. All network calls go to `config.authorizerURL`
@@ -370,6 +382,17 @@ export class Authorizer {
     }
   };
 
+  /**
+   * Exchange credentials for tokens at `/oauth/token`.
+   *
+   * Supported grants: `authorization_code` (default), `refresh_token`,
+   * `client_credentials` (RFC 6749 §4.4) and RFC 8693 token exchange
+   * (`urn:ietf:params:oauth:grant-type:token-exchange`).
+   *
+   * WARNING: `client_credentials` and token exchange are machine/service
+   * flows for trusted server-side code ONLY. Never ship `client_secret`,
+   * `client_assertion`, or subject/actor tokens in a browser bundle.
+   */
   getToken = async (
     data: Types.GetTokenRequest,
   ): Promise<Types.ApiResponse<Types.GetTokenResponse>> => {
@@ -381,13 +404,36 @@ export class Authorizer {
     if (data.grant_type === 'authorization_code' && !this.codeVerifier)
       return this.errorResponse([new Error('Invalid code verifier')]);
 
-    const requestData = {
-      client_id: this.config.clientID,
-      code: data.code || '',
-      code_verifier: this.codeVerifier || '',
-      grant_type: data.grant_type || '',
-      refresh_token: data.refresh_token || '',
+    if (
+      data.grant_type === GRANT_TYPE_TOKEN_EXCHANGE &&
+      !data.subject_token?.trim()
+    )
+      return this.errorResponse([new Error('Invalid subject_token')]);
+
+    const requestData: Record<string, string> = {
+      client_id: this.config.clientID || '',
+      grant_type: data.grant_type,
     };
+    if (data.grant_type === 'authorization_code') {
+      requestData.code = data.code || '';
+      requestData.code_verifier = this.codeVerifier || '';
+    }
+    // only include optional params that are actually set
+    const optionalParams = [
+      'refresh_token',
+      'client_secret',
+      'scope',
+      'client_assertion',
+      'client_assertion_type',
+      'subject_token',
+      'subject_token_type',
+      'actor_token',
+      'actor_token_type',
+      'resource',
+    ] as const;
+    for (const key of optionalParams) {
+      if (data[key]) requestData[key] = data[key];
+    }
 
     try {
       const fetcher = getFetcher();

--- a/src/index.ts
+++ b/src/index.ts
@@ -437,11 +437,15 @@ export class Authorizer {
 
     try {
       const fetcher = getFetcher();
+      // RFC 6749 token requests MUST be form-encoded. The server binds most
+      // params from JSON too, but reads `resource` (RFC 8707) only from the
+      // POST form — a JSON body would silently break token exchange.
       const res = await fetcher(`${this.config.authorizerURL}/oauth/token`, {
         method: 'POST',
-        body: JSON.stringify(requestData),
+        body: new URLSearchParams(requestData).toString(),
         headers: {
           ...this.config.extraHeaders,
+          'Content-Type': 'application/x-www-form-urlencoded',
         },
         credentials: 'include',
       });

--- a/src/types.ts
+++ b/src/types.ts
@@ -448,6 +448,29 @@ export interface GetTokenRequest {
   code?: string;
   grant_type?: string;
   refresh_token?: string;
+  // --- client_credentials (RFC 6749 §4.4) — SERVER-SIDE ONLY ---
+  // client_secret authenticates the service account. NEVER ship it in a
+  // browser bundle.
+  client_secret?: string;
+  // scope is the space-delimited OAuth2 scope parameter (RFC 6749 §3.3);
+  // omitted = the service account's full allowed scope set.
+  scope?: string;
+  // client_assertion / client_assertion_type carry the RFC 7523 JWT-bearer
+  // client credential — the secretless workload-identity path (K8s SA
+  // tokens, SPIFFE JWT-SVIDs, cloud OIDC tokens).
+  client_assertion?: string;
+  client_assertion_type?: string;
+  // --- RFC 8693 token exchange (delegation) — SERVER-SIDE ONLY ---
+  // subject_token carries the authority being exercised (the user's token);
+  // actor_token carries the acting agent's token (its presence selects the
+  // delegation profile). See TOKEN_TYPE_* constants for the *_token_type URNs.
+  subject_token?: string;
+  subject_token_type?: string;
+  actor_token?: string;
+  actor_token_type?: string;
+  // resource is the RFC 8707 resource indicator the issued token is
+  // audience-bound to.
+  resource?: string;
 }
 
 // Keep GetTokenInput as alias for backward compatibility
@@ -456,8 +479,15 @@ export type GetTokenInput = GetTokenRequest;
 export interface GetTokenResponse {
   access_token: string;
   expires_in: number;
-  id_token: string;
+  // id_token is only issued on user grants (authorization_code /
+  // refresh_token) — absent for client_credentials and token exchange.
+  id_token?: string;
   refresh_token?: string;
+  token_type?: string;
+  // scope / issued_token_type are returned by the client_credentials and
+  // token-exchange grants (RFC 6749 §5.1 / RFC 8693 §2.2).
+  scope?: string;
+  issued_token_type?: string;
 }
 
 // GraphQL query request
@@ -778,4 +808,358 @@ export interface GenerateJWTKeysResponse {
 // AdminSignupRequest sets the admin secret on a fresh deployment (gql-only).
 export interface AdminSignupRequest {
   admin_secret: string;
+}
+
+// ============================================================================
+// Machine-agent-identity admin types: OAuth clients (service accounts),
+// trusted issuers, organizations, org SSO connections, and SCIM endpoints.
+// ============================================================================
+
+// Client is a registered OAuth client / service account. client_secret is
+// NEVER part of this shape — it is returned exactly once in
+// CreateClientResponse (creation and rotation) and never again.
+export interface Client {
+  id: string;
+  name: string;
+  description: string | null;
+  allowed_scopes: string[];
+  is_active: boolean;
+  created_at: number | null;
+  updated_at: number | null;
+}
+
+// CreateClientResponse carries the client plus its secret. The secret is
+// returned ONCE at creation and ONCE at rotation; store it securely.
+export interface CreateClientResponse {
+  client: Client;
+  client_secret: string;
+}
+
+// Clients is a paginated list of OAuth clients.
+export interface Clients {
+  pagination: Pagination;
+  clients: Client[];
+}
+
+// CreateClientRequest registers a new OAuth client / service account.
+export interface CreateClientRequest {
+  name: string;
+  description?: string | null;
+  // allowed_scopes must contain at least one non-empty scope after trimming.
+  allowed_scopes: string[];
+}
+
+// UpdateClientRequest updates an existing client. allowed_scopes, when
+// supplied, replaces the scope set.
+export interface UpdateClientRequest {
+  id: string;
+  name?: string | null;
+  description?: string | null;
+  allowed_scopes?: string[] | null;
+  is_active?: boolean | null;
+}
+
+// ClientRequest targets a single client by id (get / delete / rotate secret).
+export interface ClientRequest {
+  id: string;
+}
+
+// ListClientsRequest is a paginated client list read.
+export interface ListClientsRequest {
+  pagination?: PaginationRequest | null;
+}
+
+// TrustedIssuer is an external token issuer trusted for secretless
+// (client_assertion) authentication of a service account.
+export interface TrustedIssuer {
+  id: string;
+  service_account_id: string;
+  name: string;
+  issuer_url: string;
+  key_source_type: string;
+  jwks_url: string | null;
+  expected_aud: string;
+  subject_claim: string;
+  // allowed_subjects: comma-separated exact subject allow-list. Empty = deny-all.
+  allowed_subjects: string | null;
+  issuer_type: string;
+  is_active: boolean;
+  spiffe_refresh_hint_seconds: number | null;
+  created_at: number | null;
+  updated_at: number | null;
+}
+
+// TrustedIssuers is a paginated list of trusted issuers.
+export interface TrustedIssuers {
+  pagination: Pagination;
+  trusted_issuers: TrustedIssuer[];
+}
+
+// AddTrustedIssuerRequest registers a trusted issuer for a service account.
+export interface AddTrustedIssuerRequest {
+  service_account_id: string;
+  name: string;
+  issuer_url: string;
+  // key_source_type: "oidc_discovery" | "static_jwks_url" | "spiffe_bundle_endpoint"
+  key_source_type: string;
+  jwks_url?: string | null;
+  expected_aud: string;
+  // subject_claim defaults to "sub" if omitted.
+  subject_claim?: string | null;
+  // allowed_subjects: comma-separated exact subject allow-list. Empty/omitted
+  // = deny-all — a row with no configured subjects authenticates nobody.
+  allowed_subjects?: string | null;
+  // issuer_type: "kubernetes_sa" | "spiffe_jwt" | "oidc" | "cloud_oidc"
+  issuer_type: string;
+  spiffe_refresh_hint_seconds?: number | null;
+}
+
+// UpdateTrustedIssuerRequest updates an existing trusted issuer.
+export interface UpdateTrustedIssuerRequest {
+  id: string;
+  name?: string | null;
+  jwks_url?: string | null;
+  expected_aud?: string | null;
+  allowed_subjects?: string | null;
+  is_active?: boolean | null;
+  spiffe_refresh_hint_seconds?: number | null;
+}
+
+// TrustedIssuerRequest targets a single trusted issuer by id (get / delete).
+export interface TrustedIssuerRequest {
+  id: string;
+}
+
+// ListTrustedIssuersRequest is a paginated, optionally service-account-scoped
+// trusted issuer list read.
+export interface ListTrustedIssuersRequest {
+  service_account_id?: string | null;
+  pagination?: PaginationRequest | null;
+}
+
+// Organization is a tenant grouping of users.
+export interface Organization {
+  id: string;
+  // name is a unique, URL-safe slug identifying the organization.
+  name: string;
+  display_name: string | null;
+  enabled: boolean;
+  created_at: number | null;
+  updated_at: number | null;
+}
+
+// Organizations is a paginated list of organizations.
+export interface Organizations {
+  pagination: Pagination;
+  organizations: Organization[];
+}
+
+// CreateOrganizationRequest creates a new organization.
+export interface CreateOrganizationRequest {
+  // name must be a unique, URL-safe slug.
+  name: string;
+  display_name?: string | null;
+}
+
+// UpdateOrganizationRequest updates an existing organization.
+export interface UpdateOrganizationRequest {
+  id: string;
+  name?: string | null;
+  display_name?: string | null;
+  enabled?: boolean | null;
+}
+
+// OrganizationRequest targets a single organization by id (get / delete).
+export interface OrganizationRequest {
+  id: string;
+}
+
+// ListOrganizationsRequest is a paginated organization list read.
+export interface ListOrganizationsRequest {
+  pagination?: PaginationRequest | null;
+}
+
+// OrgMember is a user's membership in an organization.
+export interface OrgMember {
+  id: string;
+  org_id: string;
+  user_id: string;
+  // roles is the set of per-organization roles granted to this member.
+  roles: string[];
+  created_at: number | null;
+  updated_at: number | null;
+}
+
+// OrgMembers is a paginated list of organization members.
+export interface OrgMembers {
+  pagination: Pagination;
+  org_members: OrgMember[];
+}
+
+// AddOrgMemberRequest adds a user to an organization.
+export interface AddOrgMemberRequest {
+  org_id: string;
+  user_id: string;
+  // roles defaults to an empty set when omitted.
+  roles?: string[] | null;
+}
+
+// RemoveOrgMemberRequest removes a user from an organization.
+export interface RemoveOrgMemberRequest {
+  org_id: string;
+  user_id: string;
+}
+
+// ListOrgMembersRequest is a paginated member list read for one organization.
+export interface ListOrgMembersRequest {
+  org_id: string;
+  pagination?: PaginationRequest | null;
+}
+
+// OrgOIDCConnection is a per-organization upstream OIDC IdP that Authorizer
+// brokers as a Relying Party. The upstream client_secret is NEVER projected.
+export interface OrgOIDCConnection {
+  id: string;
+  org_id: string;
+  name: string;
+  issuer_url: string;
+  // sso_client_id: the client_id Authorizer uses AT the upstream IdP.
+  sso_client_id: string;
+  scopes: string | null;
+  redirect_uri: string | null;
+  is_active: boolean;
+  created_at: number | null;
+  updated_at: number | null;
+}
+
+// CreateOrgOIDCConnectionRequest creates a per-org upstream OIDC connection.
+export interface CreateOrgOIDCConnectionRequest {
+  org_id: string;
+  name: string;
+  // issuer_url: the upstream IdP issuer (its OIDC discovery base).
+  issuer_url: string;
+  // client_id / client_secret: the credentials Authorizer holds AT the
+  // upstream IdP. The secret is stored encrypted and never returned.
+  client_id: string;
+  client_secret: string;
+  // scopes: space-separated. Defaults to "openid profile email" when omitted.
+  scopes?: string | null;
+  // redirect_uri registered at the upstream IdP. Derived from the request
+  // host when omitted.
+  redirect_uri?: string | null;
+}
+
+// UpdateOrgOIDCConnectionRequest updates a per-org upstream OIDC connection.
+export interface UpdateOrgOIDCConnectionRequest {
+  id: string;
+  name?: string | null;
+  issuer_url?: string | null;
+  client_id?: string | null;
+  // Supplying client_secret rotates it; omitting leaves the stored secret intact.
+  client_secret?: string | null;
+  scopes?: string | null;
+  redirect_uri?: string | null;
+  is_active?: boolean | null;
+}
+
+// OrgOIDCConnectionRequest looks up a connection by id OR by org_id
+// (supply exactly one).
+export interface OrgOIDCConnectionRequest {
+  id?: string | null;
+  org_id?: string | null;
+}
+
+// OrgSAMLConnection is a per-organization upstream SAML 2.0 IdP for which
+// Authorizer acts as the Service Provider. The IdP signing certificate is
+// accepted on write but never projected back.
+export interface OrgSAMLConnection {
+  id: string;
+  org_id: string;
+  name: string;
+  // idp_entity_id: the upstream IdP entity ID (the assertion Issuer).
+  idp_entity_id: string;
+  // idp_sso_url: the IdP Single Sign-On endpoint the AuthnRequest is sent to.
+  idp_sso_url: string | null;
+  // sp_entity_id / acs_url: the SP identity Authorizer advertises for this
+  // org. Empty means "derived from the request host".
+  sp_entity_id: string | null;
+  acs_url: string | null;
+  // attribute_mapping: JSON mapping profile fields to SAML attribute names.
+  attribute_mapping: string | null;
+  // allow_idp_initiated: whether IdP-initiated SSO is permitted.
+  allow_idp_initiated: boolean;
+  is_active: boolean;
+  created_at: number | null;
+  updated_at: number | null;
+}
+
+// CreateOrgSAMLConnectionRequest creates a per-org upstream SAML connection.
+export interface CreateOrgSAMLConnectionRequest {
+  org_id: string;
+  name: string;
+  // idp_entity_id: the upstream IdP entity ID (matched against the assertion
+  // Issuer). Globally unique across all trusted issuers.
+  idp_entity_id: string;
+  // idp_sso_url: the IdP Single Sign-On endpoint (HTTP-Redirect binding).
+  idp_sso_url: string;
+  // idp_certificate: the IdP X.509 signing certificate (PEM). Assertion
+  // signatures are validated ONLY against this certificate.
+  idp_certificate: string;
+  // sp_entity_id / acs_url: override the host-derived SP identity. Optional.
+  sp_entity_id?: string | null;
+  acs_url?: string | null;
+  // attribute_mapping: JSON, e.g. {"email":"email","given_name":"firstName"}.
+  attribute_mapping?: string | null;
+  // allow_idp_initiated: default false (SP-initiated only).
+  allow_idp_initiated?: boolean | null;
+}
+
+// UpdateOrgSAMLConnectionRequest updates a per-org upstream SAML connection.
+export interface UpdateOrgSAMLConnectionRequest {
+  id: string;
+  name?: string | null;
+  idp_entity_id?: string | null;
+  idp_sso_url?: string | null;
+  // Supplying idp_certificate replaces it; omitting leaves the stored cert intact.
+  idp_certificate?: string | null;
+  sp_entity_id?: string | null;
+  acs_url?: string | null;
+  attribute_mapping?: string | null;
+  allow_idp_initiated?: boolean | null;
+  is_active?: boolean | null;
+}
+
+// OrgSAMLConnectionRequest looks up a connection by id OR by org_id
+// (supply exactly one).
+export interface OrgSAMLConnectionRequest {
+  id?: string | null;
+  org_id?: string | null;
+}
+
+// ScimEndpoint is the per-org inbound SCIM 2.0 connection credential. The
+// bearer token is NEVER part of this shape — it is returned exactly once in
+// CreateScimEndpointResponse (creation and rotation) and never again.
+export interface ScimEndpoint {
+  id: string;
+  org_id: string;
+  enabled: boolean;
+  created_at: number | null;
+  updated_at: number | null;
+}
+
+// CreateScimEndpointResponse carries the endpoint plus its bearer token. The
+// token is returned ONCE at creation and ONCE at rotation; store it securely.
+export interface CreateScimEndpointResponse {
+  scim_endpoint: ScimEndpoint;
+  token: string;
+}
+
+// CreateScimEndpointRequest / ScimEndpointRequest are keyed by org_id — one
+// SCIM endpoint per org.
+export interface CreateScimEndpointRequest {
+  org_id: string;
+}
+
+export interface ScimEndpointRequest {
+  org_id: string;
 }


### PR DESCRIPTION
## What

Brings the SDK up to date with the server's machine-agent-identity program.

### getToken
- `client_credentials` grant: `client_secret`, `scope`, secretless `client_assertion`(`_type`)
- RFC 8693 token exchange: `subject_token`(`_type`), `actor_token`(`_type`), `resource`
- Only set params are serialized; `code`/`code_verifier` only sent for `authorization_code`
- JSDoc warning: machine grants are server-side-only — never ship `client_secret` in a browser bundle
- New exported constants: `GRANT_TYPE_*`, `TOKEN_TYPE_*`, `CLIENT_ASSERTION_TYPE_JWT_BEARER`

### AuthorizerAdmin — 27 new methods
- **Clients + trusted issuers**: `graphql` + `rest` (grpc-gateway routes verified against server `admin.proto`)
- **Organizations / org members / org OIDC + SAML connections / SCIM**: graphql-only (no proto RPCs server-side), erroring clearly over rest — same pattern as `adminSignup`/`generateJWTKeys`
- Full request/response types mirroring `schema.graphqls`; secret-shown-once semantics documented on `CreateClientResponse` / SCIM token rotation

## Testing
- `npm run build` (tsup ESM/CJS/DTS) + `npm run lint` pass
- New `__test__/tokenGrants.test.ts`: 11 unit tests (mocked fetch) asserting exact `/oauth/token` bodies for both grants, secretless assertion, subject_token validation, refresh regression, OAuth error surfacing, admin graphql/REST dispatch + unwrap, graphql-only rejection over rest
- Docker integration suites unchanged (need a published server image with the MAI surface)