### PR TITLE
chore: release 3.3.0-rc.0 (RC-aware npm publish)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,14 +30,27 @@ jobs:
         run: pnpm build
 
       - name: Publish to npm
-        run: pnpm publish --no-git-checks --access public
+        run: |
+          # Prereleases MUST NOT land on the `latest` dist-tag, or a plain
+          # `npm install @authorizerdev/authorizer-js` would pull an RC.
+          if [[ "${GITHUB_REF_NAME}" == *-rc.* ]]; then
+            pnpm publish --no-git-checks --access public --tag rc
+          elif [[ "${GITHUB_REF_NAME}" == *-beta.* ]]; then
+            pnpm publish --no-git-checks --access public --tag beta
+          else
+            pnpm publish --no-git-checks --access public
+          fi
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Create GitHub Release
         run: |
+          PRERELEASE=""
+          if [[ "${GITHUB_REF_NAME}" == *-rc.* || "${GITHUB_REF_NAME}" == *-beta.* ]]; then
+            PRERELEASE="--prerelease"
+          fi
           gh release create "${{ github.ref_name }}" \
             --title "${{ github.ref_name }}" \
-            --generate-notes
+            --generate-notes $PRERELEASE
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@authorizerdev/authorizer-js",
-  "version": "3.2.1",
+  "version": "3.3.0-rc.0",
   "packageManager": "pnpm@8.15.6",
   "author": "Lakhan Samani",
   "license": "MIT",


### PR DESCRIPTION
Prep for the RC release cascade so the ecosystem can be e2e-tested.

- Bumps to **3.3.0-rc.0** — ships the merged WebAuthn/passkey SDK methods (#41) and GraphQL `extensions.code` error surfacing (#39).
- **Fixes an npm-publish footgun:** the release workflow ran a plain `pnpm publish` (→ `latest`) regardless of version, so tagging an RC would have made `3.3.0-rc.0` the default install and broken `npm install @authorizerdev/authorizer-js` for everyone. Now `-rc.`/`-beta.` tags publish to the `rc`/`beta` dist-tag and the GitHub release is marked prerelease.

After merge, pushing tag `v3.3.0-rc.0` publishes to npm under the `rc` dist-tag (`npm install @authorizerdev/authorizer-js@rc`).