### PR TITLE
feat(meta): add per-method MFA availability fields + bump 3.3.0-rc.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@authorizerdev/authorizer-js",
-  "version": "3.3.0-rc.0",
+  "version": "3.3.0-rc.1",
   "packageManager": "pnpm@8.15.6",
   "author": "Lakhan Samani",
   "license": "MIT",

--- a/src/index.ts
+++ b/src/index.ts
@@ -244,7 +244,7 @@ export class Authorizer {
         ['graphql', 'rest'],
         {
           query:
-            'query meta { meta { version client_id is_google_login_enabled is_facebook_login_enabled is_github_login_enabled is_linkedin_login_enabled is_apple_login_enabled is_discord_login_enabled is_twitter_login_enabled is_microsoft_login_enabled is_twitch_login_enabled is_roblox_login_enabled is_email_verification_enabled is_basic_authentication_enabled is_magic_link_login_enabled is_sign_up_enabled is_strong_password_enabled is_multi_factor_auth_enabled is_mobile_basic_authentication_enabled is_phone_verification_enabled } }',
+            'query meta { meta { version client_id is_google_login_enabled is_facebook_login_enabled is_github_login_enabled is_linkedin_login_enabled is_apple_login_enabled is_discord_login_enabled is_twitter_login_enabled is_microsoft_login_enabled is_twitch_login_enabled is_roblox_login_enabled is_email_verification_enabled is_basic_authentication_enabled is_magic_link_login_enabled is_sign_up_enabled is_strong_password_enabled is_multi_factor_auth_enabled is_mobile_basic_authentication_enabled is_phone_verification_enabled is_totp_mfa_enabled is_email_otp_mfa_enabled is_sms_otp_mfa_enabled is_webauthn_enabled } }',
           operationName: 'meta',
           op: 'meta',
         },

--- a/src/types.ts
+++ b/src/types.ts
@@ -68,6 +68,12 @@ export interface Meta {
   is_multi_factor_auth_enabled: boolean;
   is_mobile_basic_authentication_enabled: boolean;
   is_phone_verification_enabled: boolean;
+  // Per-method MFA availability for the login UI (server derives email/SMS from
+  // their provider being configured; webauthn is always available).
+  is_totp_mfa_enabled: boolean;
+  is_email_otp_mfa_enabled: boolean;
+  is_sms_otp_mfa_enabled: boolean;
+  is_webauthn_enabled: boolean;
 }
 
 // User


### PR DESCRIPTION
Adds the per-method MFA availability fields to the SDK's `Meta` type and `getMetaData` query, matching the server surface merged in authorizer#681, and bumps to `3.3.0-rc.1` for the RC that also carries passkey autofill (#43).

## Added to `Meta` + `getMetaData`
- `is_totp_mfa_enabled`
- `is_email_otp_mfa_enabled`
- `is_sms_otp_mfa_enabled`
- `is_webauthn_enabled`

## ⚠️ Release coupling (CI note)
These fields exist only on an authorizer server **≥ today's main** (added in #681). The integration test / CI pins `AUTHORIZER_IMAGE=quay.io/authorizer/authorizer:2.3.0`, which predates them — so the `getMetaData` integration test fails there with *"Cannot query field is_totp_mfa_enabled"*. This is pure version skew; the change is correct against server `main`. CI goes green once a server RC image carrying #681 is published and `AUTHORIZER_IMAGE` is bumped to it. Unit tests + build + DTS typecheck pass.