### PR TITLE
fix(types)!: remove is_multi_factor_auth_enabled from SignUpRequest

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -205,7 +205,6 @@ export interface SignUpRequest {
   roles?: string[] | null;
   scope?: string[] | null;
   redirect_uri?: string | null;
-  is_multi_factor_auth_enabled?: boolean | null;
   state?: string | null;
   app_data?: Record<string, any> | null;
 }


### PR DESCRIPTION
## Why

Server PR authorizerdev/authorizer#710 (release `2.4.0-rc.6`) removed `is_multi_factor_auth_enabled` from `SignupRequest` / `input SignUpRequest` in both the GraphQL schema and the proto message. It was a security fix: the field let an unauthenticated signup caller bypass the server's MFA-on-by-default policy for their own new account.

## What changed

- `src/types.ts`: removed `is_multi_factor_auth_enabled` from the `SignUpRequest` interface (and its `SignupRequest` alias). The `signup()` mutation in `src/index.ts` sends the whole typed object as GraphQL variables, so no separate query-string change was needed.

## Scope

Narrowly scoped to this one breaking field removal on the signup path only:

- `UpdateProfileRequest` / `updateProfile()` — **untouched**. The field remains valid and required there.
- Admin `UpdateUserRequest` / `updateUser()` (`src/admin.ts`) — **untouched**. Same, unaffected by the server change.
- No README/example code referenced this field on the signup path (grepped, none found).
- `src/admin.ts`'s `adminSignup`/`AdminSignupRequest` never had this field — unaffected.

This is a breaking change for TS consumers who set `is_multi_factor_auth_enabled` on `signup()` — expected, matching the server's break. It is additive-safe (removing an optional field is source-compatible for anyone who wasn't already setting it).

## Verification

- `npm run build` — passes, no type errors.
- `npx tsc --noEmit` — clean, no other references to the field on the signup path.
- `npx jest` — 7/9 suites pass. The 2 failing suites (`index.test.ts`, `admin.test.ts`) fail identically on `main` before this change too — they spin up a real Authorizer server via Docker pinned to `quay.io/authorizer/authorizer:2.4.0-rc.1`, which is a 404 in the registry (pre-existing environment/pinned-tag issue, unrelated to this diff).

Refs authorizerdev/authorizer#710