### PR TITLE
fix!: match the backend's standardized single-level pagination shape

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,4 +32,4 @@ jobs:
       - name: Run integration tests
         run: pnpm test # Make sure this command runs your integration tests
         env:
-          AUTHORIZER_IMAGE: quay.io/authorizer/authorizer:2.4.0-rc.7
+          AUTHORIZER_IMAGE: quay.io/authorizer/authorizer:2.4.0-rc.9

--- a/__test__/admin.test.ts
+++ b/__test__/admin.test.ts
@@ -190,7 +190,7 @@ describe('Integration Tests - AuthorizerAdmin (graphql + rest)', () => {
       });
       expect(addRes.errors).toHaveLength(0);
 
-      const listRes = await a.webhooks({ pagination: { limit: 50, page: 1 } });
+      const listRes = await a.webhooks({ limit: 50, page: 1 });
       expect(listRes.errors).toHaveLength(0);
       const created = listRes.data?.webhooks.find((w) =>
         (w.event_name ?? '').startsWith(event),
@@ -219,9 +219,7 @@ describe('Integration Tests - AuthorizerAdmin (graphql + rest)', () => {
       });
       expect(addRes.errors).toHaveLength(0);
 
-      const listRes = await a.emailTemplates({
-        pagination: { limit: 50, page: 1 },
-      });
+      const listRes = await a.emailTemplates({ limit: 50, page: 1 });
       expect(listRes.errors).toHaveLength(0);
       const created = listRes.data?.email_templates.find(
         (t) => t.event_name === event,

--- a/src/admin.ts
+++ b/src/admin.ts
@@ -366,13 +366,13 @@ export class AuthorizerAdmin {
 
   // verificationRequests returns a paginated list of pending verification requests.
   verificationRequests = (
-    params?: Types.PaginatedRequest,
+    params?: Types.PaginationRequest,
   ): Promise<Types.ApiResponse<Types.VerificationRequests>> =>
     this.dispatch<Types.VerificationRequests>(
       'VerificationRequests',
       ['graphql', 'rest'],
       {
-        query: `query _verification_requests($params: PaginatedRequest) { _verification_requests(params: $params) { pagination { ${paginationFragment} } verification_requests { id identifier token email expires created_at updated_at nonce redirect_uri } } }`,
+        query: `query _verification_requests($params: PaginationRequest) { _verification_requests(params: $params) { pagination { ${paginationFragment} } verification_requests { id identifier token email expires created_at updated_at nonce redirect_uri } } }`,
         operationName: '_verification_requests',
         op: '_verification_requests',
       },
@@ -515,13 +515,13 @@ export class AuthorizerAdmin {
 
   // webhooks returns a paginated list of webhooks.
   webhooks = (
-    params?: Types.PaginatedRequest,
+    params?: Types.PaginationRequest,
   ): Promise<Types.ApiResponse<Types.Webhooks>> =>
     this.dispatch<Types.Webhooks>(
       'Webhooks',
       ['graphql', 'rest'],
       {
-        query: `query _webhooks($params: PaginatedRequest) { _webhooks(params: $params) { pagination { ${paginationFragment} } webhooks { ${webhookFragment} } } }`,
+        query: `query _webhooks($params: PaginationRequest) { _webhooks(params: $params) { pagination { ${paginationFragment} } webhooks { ${webhookFragment} } } }`,
         operationName: '_webhooks',
         op: '_webhooks',
       },
@@ -626,13 +626,13 @@ export class AuthorizerAdmin {
 
   // emailTemplates returns a paginated list of email templates.
   emailTemplates = (
-    params?: Types.PaginatedRequest,
+    params?: Types.PaginationRequest,
   ): Promise<Types.ApiResponse<Types.EmailTemplates>> =>
     this.dispatch<Types.EmailTemplates>(
       'EmailTemplates',
       ['graphql', 'rest'],
       {
-        query: `query _email_templates($params: PaginatedRequest) { _email_templates(params: $params) { pagination { ${paginationFragment} } email_templates { ${emailTemplateFragment} } } }`,
+        query: `query _email_templates($params: PaginationRequest) { _email_templates(params: $params) { pagination { ${paginationFragment} } email_templates { ${emailTemplateFragment} } } }`,
         operationName: '_email_templates',
         op: '_email_templates',
       },

--- a/src/types.ts
+++ b/src/types.ts
@@ -643,11 +643,6 @@ export interface AdminMeta {
   is_multi_factor_auth_service_enabled: boolean;
 }
 
-// PaginatedRequest wraps the pagination input for list queries.
-export interface PaginatedRequest {
-  pagination?: PaginationRequest | null;
-}
-
 // ListUsersRequest is the admin _users query input. query is an optional
 // case-insensitive substring filter matched against email, given_name,
 // family_name and nickname. Empty/absent means no filter (full list).


### PR DESCRIPTION
## Summary

- The Authorizer backend removed the `PaginatedRequest` wrapper type entirely (see the corresponding `authorizerdev/authorizer` PR — a `fix(graphql)!` breaking-change commit standardizing GraphQL pagination on `PaginationRequest` directly, matching the proto/gRPC surface, which never had a double-wrapper)
- This SDK's `verificationRequests`/`webhooks`/`emailTemplates` methods hardcoded `PaginatedRequest` in both their GraphQL query strings and their `Types.PaginatedRequest` parameter type — both updated to `PaginationRequest` directly
- **Breaking change for callers**: `.webhooks({ pagination: { limit: 10 } })` becomes `.webhooks({ limit: 10 })` (same for `emailTemplates`/`verificationRequests`)
- The 6 `List*Request` types (`Clients`/`TrustedIssuers`/`SAMLServiceProviders`/`Organizations`/`OrgDomains`/`OrgMembers`) needed **no change** here: their `pagination` field was already typed as `PaginationRequest` in this SDK, even though the *old* backend schema actually required the `PaginatedRequest` wrapper for those — meaning no strictly-typed caller of this SDK could have constructed the shape the old schema demanded for those 6 endpoints in the first place. The backend fix makes those types correct rather than accidentally correct.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `pnpm build` clean
- [x] Verified against a locally built `authorizer` image running the backend fix (not yet released): all 26 `admin.test.ts` integration tests pass (graphql + rest transports), including the 2 test call sites updated to the new flat pagination shape
- [x] Confirmed against the currently-published `quay.io/authorizer/authorizer:latest` image (predates the backend fix) that the *old* server correctly rejects the new shape with `Variable "$params" of type "PaginationRequest" used in position expecting type "PaginatedRequest"` — expected, and confirms this SDK change is correctly coordinated with (not accidentally divergent from) the backend fix

**Please coordinate merging/releasing this alongside the backend fix** — until the backend PR ships, this SDK version would send a shape the currently-deployed backend rejects.